### PR TITLE
fix: run event hooks as direct argv instead of through sh

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -15,24 +15,24 @@ command = ["npm", "ci"]
 command = ["npm", "run", "build"]
 
 # Global socket subscriptions require a pane id, so each event runs a short-lived manifest hook.
-# Hook cwd is unspecified; resolve the entrypoint from the plugin root.
+# Herdr runs hooks from the plugin root, so direct argv needs no shell expansion.
 [[events]]
 on = "pane.agent_status_changed"
-command = ["sh", "-c", "exec node \"${HERDR_PLUGIN_ROOT:-.}/dist/bin/event.js\""]
+command = ["node", "dist/bin/event.js"]
 
 [[events]]
 on = "pane.exited"
-command = ["sh", "-c", "exec node \"${HERDR_PLUGIN_ROOT:-.}/dist/bin/event.js\""]
+command = ["node", "dist/bin/event.js"]
 
 [[events]]
 on = "pane.closed"
-command = ["sh", "-c", "exec node \"${HERDR_PLUGIN_ROOT:-.}/dist/bin/event.js\""]
+command = ["node", "dist/bin/event.js"]
 
 [[events]]
 on = "worktree.removed"
-command = ["sh", "-c", "exec node \"${HERDR_PLUGIN_ROOT:-.}/dist/bin/event.js\""]
+command = ["node", "dist/bin/event.js"]
 
-# The pane runs from the reviewed worktree. Its trailing action id carries mode across processes.
+# Panes run from the reviewed worktree, so use HERDR_PLUGIN_ROOT; the final argument selects mode.
 [[panes]]
 id = "review"
 title = "hunk review"

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -139,6 +139,17 @@ describe("herdr-plugin.toml", () => {
       for (const command of commands()) expect(command).toContain("dist/bin/event.js");
     });
 
+    it("runs every hook as direct argv, without a shell", () => {
+      for (const event of manifest.events) {
+        expect(event.command[0]).toBe("node");
+        expect(event.command).toContain("dist/bin/event.js");
+        for (const word of event.command) {
+          expect(word).not.toMatch(/^(sh|bash|zsh|cmd|cmd\.exe|powershell)$/);
+          expect(word).not.toContain("${");
+        }
+      }
+    });
+
     it("filters no hook by pane id, since none of these types requires one", () => {
       for (const event of manifest.events) expect(event.pane_id).toBeUndefined();
     });


### PR DESCRIPTION
Removes the unnecessary POSIX shell wrapper from event hooks.

Herdr 0.8 runs event commands from the plugin root, so `dist/bin/event.js` resolves directly as `["node", "dist/bin/event.js"]`. Pane commands keep their wrapper because `plugin pane open --cwd` runs them from the reviewed worktree.

This removes one Windows incompatibility without changing pane behavior. Full Windows support remains in #10.

Validation:

- Manifest coverage requires direct event argv with no shell expansion.
- Formatting, lint, and the manifest tests pass.
- Command cwd behavior was verified against Herdr 0.8.0.
