### PR TITLE
chore(release): prepare 0.2.0

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "jhochenbaum.hunkdiff"
 name = "hunk"
-version = "0.1.0"
+version = "0.2.0"
 
 # Requires plugin-root-relative action commands and reliable agent prompt submission from Herdr 0.8.
 min_herdr_version = "0.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "herdr-hunk-diff",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herdr-hunk-diff",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "hunkdiff": "0.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herdr-hunk-diff",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A herdr plugin that reviews agent-authored diffs in hunk and sends your inline comments back to the agent that wrote them.",
   "license": "MIT",
   "author": "Jordan Hochenbaum",


### PR DESCRIPTION
Bumps `package.json` and `herdr-plugin.toml` to `0.2.0` so the work on `main` since v0.1.0 can be tagged.

Minor rather than patch: #10 added Windows as a supported platform. `min_herdr_version` stays at `0.8.0` — nothing in the Windows work needs a newer herdr.

### Why this release matters

v0.1.0's release notes still say "macOS or Linux" and advertise the pinned `hunkdiff` as `0.18.1`. Both have been wrong on `main` since #10 and #11. Anyone reading the latest release concludes the plugin won't run on their Windows machine.

### What's in it

| PR | Change |
| --- | --- |
| #10 | Windows support |
| #9 | Event hooks run as direct argv instead of through `sh` |
| #11 | `hunkdiff` 0.18.1 → 0.19.0 |
| #12, #13 | `smol-toml`, `globals` |

### Verification

`npm ci && npm run check && npm run build && npm test` locally against `hunkdiff` 0.19.0 — 27 files, 668 tests, all passing.

---

### Draft release notes for v0.2.0

Copy-paste ready, styled after v0.1.0. Not committed anywhere — this repo has no CHANGELOG, so the release body is the changelog.

> **Windows support.** Reviews, panes, event hooks and keybindings now work on Windows alongside macOS and Linux. Panes launch through `cmd /c` so `%HERDR_PLUGIN_ROOT%` expands, and the pager, worktree and keybinding paths all handle Windows path separators. hunk ships prebuilt binaries for x64 only, so reviews cannot open on Windows on ARM.
>
> **Event hooks are more reliable.** Manifest event hooks run as direct argv instead of through `sh`, so they no longer depend on a POSIX shell being present or on shell quoting surviving the round trip.
>
> **hunk 0.19.0.** The pinned `hunkdiff` dependency moves from 0.18.1 to 0.19.0, bringing faster diffs in repositories with many untracked files, syntax caches that follow the active review, and provenance-attested release archives. This plugin drives hunk through its CLI, so the upgrade needs no changes on your side.
>
> Requires herdr 0.8.0 or newer, Node 22.12 or newer, macOS, Linux or Windows. The pinned `hunkdiff` 0.19.0 dependency installs automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
