### PR TITLE
feat: add multi-repository review picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,17 +151,18 @@ herdr server reload-config
 
 **Everything else**
 
-| Action            | Effect                                                    |
-| ----------------- | --------------------------------------------------------- |
-| `send-review`     | Send all unsent inline comments to the associated agent   |
-| `reload`          | Reload the target shown in the current review pane        |
-| `close-review`    | Close the review pane for the current worktree            |
-| `next-comment`    | Move hunk to the next annotated hunk                      |
-| `prev-comment`    | Move hunk to the previous annotated hunk                  |
-| `setup-keys`      | Install the default herdr keybindings                     |
-| `remove-keys`     | Remove only the keybinding block installed by this plugin |
-| `install-pager`   | Configure supported VCS pagers                            |
-| `uninstall-pager` | Remove pager configuration owned by this plugin           |
+| Action             | Effect                                                               |
+| ------------------ | -------------------------------------------------------------------- |
+| `send-review`      | Send all unsent inline comments to the associated agent              |
+| `send-review:pick` | Choose any live agent in the current workspace, then send the review |
+| `reload`           | Reload the target shown in the current review pane                   |
+| `close-review`     | Close the review pane for the current worktree                       |
+| `next-comment`     | Move hunk to the next annotated hunk                                 |
+| `prev-comment`     | Move hunk to the previous annotated hunk                             |
+| `setup-keys`       | Install the default herdr keybindings                                |
+| `remove-keys`      | Remove only the keybinding block installed by this plugin            |
+| `install-pager`    | Configure supported VCS pagers                                       |
+| `uninstall-pager`  | Remove pager configuration owned by this plugin                      |
 
 Invoke any action from the CLI with:
 
@@ -191,6 +192,17 @@ repository has no agent pane, the review still opens; sending requires an associ
 an earlier agent event or review.
 
 The picker is implemented by the plugin and has no `fzf` or shell-script dependency.
+
+If several agents share a workspace and you want to choose the recipient at send time, invoke
+`send-review:pick`. This selection becomes the worktree's association for subsequent ordinary
+`send-review` actions:
+
+```bash
+herdr plugin action invoke send-review:pick --plugin jhochenbaum.hunkdiff
+```
+
+The action is deliberately not assigned a default key because Herdr already uses several natural
+`prefix+alt+...` candidates. Add a project-specific binding if you have freed one in your config.
 
 ### Base branch resolution
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://github.com/user-attachments/assets/a36991a9-288f-4c8a-845c-ce2399334b9b
 - [Requirements](#requirements)
 - [Quick start](#quick-start)
 - [Keybinding behavior](#keybinding-behavior)
-- [Review actions](#review-actions) &middot; [Base branch resolution](#base-branch-resolution) &middot; [GitHub commit links](#github-commit-links)
+- [Review actions](#review-actions) &middot; [Multi-repository workspaces](#multi-repository-workspaces) &middot; [Base branch resolution](#base-branch-resolution) &middot; [GitHub commit links](#github-commit-links)
 - [Configuration](#configuration) &middot; [Options](#option-reference) &middot; [Automatic opening](#automatic-opening) &middot; [Target and display](#review-target-and-display) &middot; [Round-trip prompts](#round-trip-prompts) &middot; [Hunk executable](#hunk-executable)
 - [Optional VCS pager setup](#optional-vcs-pager-setup)
 - [Direct hunk workflows](#direct-hunk-workflows)
@@ -91,6 +91,7 @@ herdr plugin action invoke send-review \
 | `prefix+shift+s` | Send review to agent   |
 | `prefix+shift+c` | Review the last commit |
 | `prefix+shift+a` | Review staged changes  |
+| `prefix+alt+h`   | Pick repository/base   |
 
 ### 3. Review and send
 
@@ -146,6 +147,7 @@ herdr server reload-config
 | `review:branch` | `<base>...HEAD`; falls back to the working tree with a warning when no base can be resolved                |
 | `review:commit` | The latest commit, or a locally available commit from a Ctrl-clicked GitHub commit URL                     |
 | `review:stash`  | The most recent stash entry                                                                                |
+| `review:pick`   | Choose a repository, base branch, and feedback agent from the current multi-repository workspace           |
 
 **Everything else**
 
@@ -166,6 +168,29 @@ Invoke any action from the CLI with:
 ```bash
 herdr plugin action invoke <action> --plugin jhochenbaum.hunkdiff
 ```
+
+### Multi-repository workspaces
+
+Use `review:pick` when panes in one Herdr workspace belong to different repositories:
+
+```bash
+herdr plugin action invoke review:pick --plugin jhochenbaum.hunkdiff
+```
+
+The temporary picker inspects every pane in the current workspace, prefers each pane's foreground
+working directory, and canonicalizes it to a Git repository root. It then asks for:
+
+1. the repository to review;
+2. the base branch for a `<base>...HEAD` review; and
+3. the destination agent when more than one agent is working in that repository.
+
+The current repository and Git's normally resolved base are listed first. Selecting an agent also
+associates that pane with the chosen repository, so `send-review` routes the comments back to the
+right worker even when the review pane is opened from a different repository. If the selected
+repository has no agent pane, the review still opens; sending requires an association recorded by
+an earlier agent event or review.
+
+The picker is implemented by the plugin and has no `fzf` or shell-script dependency.
 
 ### Base branch resolution
 
@@ -423,6 +448,7 @@ Invalid TOML and invalid values fall back to defaults.
 ## Known limitations
 
 - Review actions cannot receive pathspecs, patch paths, file pairs, or arbitrary revisions.
+- `review:pick` discovers only Git repositories represented by panes in the current workspace.
 - Stash reviews cannot be reloaded in place; close and reopen them.
 - Sending comments is explicit through `send-review`; closing a pane does not send them.
 - GitHub links support commits already present locally, not pull requests.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -118,6 +118,20 @@ placement = "overlay"
 platforms = ["windows"]
 command = ["cmd", "/c", "node \"%HERDR_PLUGIN_ROOT%\\dist\\bin\\picker.js\""]
 
+[[panes]]
+id = "send-review-picker"
+title = "pick a review recipient"
+placement = "overlay"
+platforms = ["macos", "linux"]
+command = ["sh", "-c", "exec node \"$HERDR_PLUGIN_ROOT/dist/bin/send-picker.js\""]
+
+[[panes]]
+id = "send-review-picker-windows"
+title = "pick a review recipient"
+placement = "overlay"
+platforms = ["windows"]
+command = ["cmd", "/c", "node \"%HERDR_PLUGIN_ROOT%\\dist\\bin\\send-picker.js\""]
+
 [[actions]]
 id = "review"
 title = "hunk: review changes"
@@ -183,6 +197,12 @@ id = "review:pick"
 title = "hunk: pick a repository and base to review"
 contexts = ["workspace", "pane"]
 command = ["node", "dist/bin/action.js", "review:pick"]
+
+[[actions]]
+id = "send-review:pick"
+title = "hunk: pick an agent and send review"
+contexts = ["workspace", "pane"]
+command = ["node", "dist/bin/action.js", "send-review:pick"]
 
 [[actions]]
 id = "next-comment"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -104,6 +104,20 @@ placement = "split"
 platforms = ["windows"]
 command = ["cmd", "/c", "node \"%HERDR_PLUGIN_ROOT%\\dist\\bin\\pane.js\" review:stash"]
 
+[[panes]]
+id = "review-picker"
+title = "pick a hunk review target"
+placement = "overlay"
+platforms = ["macos", "linux"]
+command = ["sh", "-c", "exec node \"$HERDR_PLUGIN_ROOT/dist/bin/picker.js\""]
+
+[[panes]]
+id = "review-picker-windows"
+title = "pick a hunk review target"
+placement = "overlay"
+platforms = ["windows"]
+command = ["cmd", "/c", "node \"%HERDR_PLUGIN_ROOT%\\dist\\bin\\picker.js\""]
+
 [[actions]]
 id = "review"
 title = "hunk: review changes"
@@ -163,6 +177,12 @@ id = "review:stash"
 title = "hunk: review the most recent stash entry"
 contexts = ["workspace"]
 command = ["node", "dist/bin/action.js", "review:stash"]
+
+[[actions]]
+id = "review:pick"
+title = "hunk: pick a repository and base to review"
+contexts = ["workspace", "pane"]
+command = ["node", "dist/bin/action.js", "review:pick"]
 
 [[actions]]
 id = "next-comment"

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -14,6 +14,9 @@ export type ReviewActionId = (typeof REVIEW_ACTIONS)[number];
 /** Opens the repository/base/agent picker instead of a review directly. */
 export const PICK_REVIEW_ACTION = "review:pick";
 
+/** Opens an agent picker and sends the current review to the selected agent. */
+export const PICK_SEND_ACTION = "send-review:pick";
+
 export function isReviewAction(id: string): id is ReviewActionId {
   return (REVIEW_ACTIONS as readonly string[]).includes(id);
 }
@@ -51,6 +54,10 @@ export const WINDOWS_PANE_SUFFIX = "-windows";
 
 export function pickerEntrypointFor(platform: NodeJS.Platform = process.platform): string {
   return platform === "win32" ? `review-picker${WINDOWS_PANE_SUFFIX}` : "review-picker";
+}
+
+export function sendPickerEntrypointFor(platform: NodeJS.Platform = process.platform): string {
+  return platform === "win32" ? `send-review-picker${WINDOWS_PANE_SUFFIX}` : "send-review-picker";
 }
 
 export function paneEntrypointFor(

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -11,6 +11,9 @@ export const REVIEW_ACTIONS = [
 
 export type ReviewActionId = (typeof REVIEW_ACTIONS)[number];
 
+/** Opens the repository/base/agent picker instead of a review directly. */
+export const PICK_REVIEW_ACTION = "review:pick";
+
 export function isReviewAction(id: string): id is ReviewActionId {
   return (REVIEW_ACTIONS as readonly string[]).includes(id);
 }
@@ -45,6 +48,10 @@ const PANE_ENTRYPOINTS: Record<string, string> = {
 
 /** Selects the cmd-based manifest entry for a Windows pane. */
 export const WINDOWS_PANE_SUFFIX = "-windows";
+
+export function pickerEntrypointFor(platform: NodeJS.Platform = process.platform): string {
+  return platform === "win32" ? `review-picker${WINDOWS_PANE_SUFFIX}` : "review-picker";
+}
 
 export function paneEntrypointFor(
   id: ReviewActionId,

--- a/src/bin/picker.ts
+++ b/src/bin/picker.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { runTerminalReviewPicker } from "../picker.js";
+import { buildRuntime } from "../runtime.js";
+import { isMainModule } from "./main-guard.js";
+
+if (isMainModule(import.meta.url)) {
+  process.exit(await runTerminalReviewPicker(buildRuntime(process.env)));
+}

--- a/src/bin/send-picker.ts
+++ b/src/bin/send-picker.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { runTerminalSendReviewPicker } from "../picker.js";
+import { buildRuntime } from "../runtime.js";
+import { isMainModule } from "./main-guard.js";
+
+if (isMainModule(import.meta.url)) {
+  process.exit(await runTerminalSendReviewPicker(buildRuntime(process.env)));
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -66,3 +66,28 @@ export function hasCommitsAhead(repo: string, base: string, run: Runner): boolea
 export function commitExists(repo: string, ref: string, run: Runner): boolean {
   return run("git", ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`]).status === 0;
 }
+
+/** Lists concrete local and remote branch refs, excluding symbolic and self-comparison refs. */
+export function listBaseRefs(repo: string, run: Runner): string[] {
+  const result = run("git", [
+    "for-each-ref",
+    "--format=%(refname:short)%09%(symref)",
+    "refs/heads",
+    "refs/remotes",
+  ]);
+  if (result.status !== 0) return [];
+
+  const current = run("git", ["symbolic-ref", "--quiet", "--short", "HEAD"]);
+  const branch = current.status === 0 ? current.stdout.trim() : "";
+
+  return [
+    ...new Set(
+      result.stdout
+        .split("\n")
+        .map((line) => line.split("\t"))
+        .filter(([ref, symref]) => Boolean(ref) && !symref)
+        .map(([ref]) => ref!)
+        .filter((ref) => !branch || !namesBranch(ref, branch)),
+    ),
+  ].sort();
+}

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -13,6 +13,15 @@ export interface HerdrAgent {
   agent_status?: string;
 }
 
+export interface HerdrPane {
+  pane_id?: string;
+  workspace_id?: string;
+  cwd?: string;
+  foreground_cwd?: string;
+  agent?: string;
+  display_agent?: string;
+}
+
 /** Reports through both the user notification channel and Herdr's captured stderr. */
 export function reportFailure(herdr: { notify: (message: string) => void }, message: string): 1 {
   console.error(`hunkdiff: ${message}`);
@@ -111,6 +120,30 @@ export class HerdrAdapter {
           pane_id: asString(agent.pane_id),
           cwd: asString(agent.cwd),
           agent_status: asString(agent.agent_status),
+        },
+      ];
+    });
+  }
+
+  /** Lists panes so workspace-scoped tools can discover repositories beyond the focused pane. */
+  paneList(workspaceId?: string): HerdrPane[] {
+    const args = ["pane", "list"];
+    if (workspaceId) args.push("--workspace", workspaceId);
+    const response = this.json(args);
+    const panes = asObject(response?.result)?.panes;
+    if (!Array.isArray(panes)) return [];
+
+    return panes.flatMap((value): HerdrPane[] => {
+      const pane = asObject(value);
+      if (!pane) return [];
+      return [
+        {
+          pane_id: asString(pane.pane_id),
+          workspace_id: asString(pane.workspace_id),
+          cwd: asString(pane.cwd),
+          foreground_cwd: asString(pane.foreground_cwd),
+          agent: asString(pane.agent),
+          display_agent: asString(pane.display_agent),
         },
       ];
     });

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -32,6 +32,11 @@ export const DEFAULT_BINDINGS: Binding[] = [
     action: `${PLUGIN_ID}.review:staged`,
     description: "hunk: review staged changes",
   },
+  {
+    key: "prefix+alt+h",
+    action: `${PLUGIN_ID}.review:pick`,
+    description: "hunk: pick a repository and base to review",
+  },
 ];
 
 export class ConfigParseError extends Error {

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -1,0 +1,187 @@
+import { basename } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import type { HerdrPane } from "./herdr.js";
+import { listBaseRefs, realRunner, repoRoot, resolveBaseRef, type Runner } from "./git.js";
+import { reportFailure } from "./herdr.js";
+import { openReviewTarget, type ReviewAssociation, type Runtime } from "./runtime.js";
+import type { Target } from "./target.js";
+
+export interface AgentChoice extends ReviewAssociation {
+  paneId: string;
+  label: string;
+}
+
+export interface RepositoryChoice {
+  worktree: string;
+  agents: AgentChoice[];
+}
+
+export interface PickerIo {
+  write: (text: string) => void;
+  ask: (prompt: string) => Promise<string>;
+}
+
+export type RepoRoot = (dir: string) => string | null;
+
+/** Groups every Git checkout represented by a pane in the current Herdr workspace. */
+export function discoverRepositories(
+  panes: HerdrPane[],
+  currentWorktree: string,
+  rootFor: RepoRoot,
+): RepositoryChoice[] {
+  const repositories = new Map<string, RepositoryChoice>();
+
+  const ensure = (dir: string | undefined): RepositoryChoice | undefined => {
+    if (!dir) return undefined;
+    const worktree = rootFor(dir);
+    if (!worktree) return undefined;
+    let repository = repositories.get(worktree);
+    if (!repository) {
+      repository = { worktree, agents: [] };
+      repositories.set(worktree, repository);
+    }
+    return repository;
+  };
+
+  const current = ensure(currentWorktree)?.worktree;
+  for (const pane of panes) {
+    const repository = ensure(pane.foreground_cwd ?? pane.cwd);
+    if (!repository || !pane.pane_id || !pane.agent) continue;
+    if (repository.agents.some((agent) => agent.paneId === pane.pane_id)) continue;
+    repository.agents.push({
+      paneId: pane.pane_id,
+      agentPaneId: pane.pane_id,
+      agentName: pane.display_agent ?? pane.agent,
+      label: `${pane.display_agent ?? pane.agent} (${pane.pane_id})`,
+    });
+  }
+
+  return [...repositories.values()].sort((a, b) => {
+    if (a.worktree === current) return -1;
+    if (b.worktree === current) return 1;
+    return a.worktree.localeCompare(b.worktree);
+  });
+}
+
+interface NumberedChoice<T> {
+  label: string;
+  value: T;
+}
+
+/** A dependency-free picker suitable for the plugin's temporary overlay pane. */
+export async function chooseNumbered<T>(
+  title: string,
+  choices: NumberedChoice<T>[],
+  io: PickerIo,
+): Promise<T | undefined> {
+  if (choices.length === 0) return undefined;
+  if (choices.length === 1) return choices[0]!.value;
+
+  io.write(`\n${title}\n`);
+  choices.forEach((choice, index) => io.write(`  ${index + 1}. ${choice.label}\n`));
+  for (;;) {
+    const answer = (await io.ask(`\nSelect [1-${choices.length}, q to cancel]: `)).trim();
+    if (answer.toLowerCase() === "q") return undefined;
+    const selected = Number.parseInt(answer, 10);
+    if (Number.isInteger(selected) && selected >= 1 && selected <= choices.length) {
+      return choices[selected - 1]!.value;
+    }
+    io.write("Enter one of the listed numbers, or q to cancel.\n");
+  }
+}
+
+export function targetChoices(repo: string, run: Runner): Array<NumberedChoice<Target>> {
+  const preferred = resolveBaseRef(repo, run);
+  const bases = listBaseRefs(repo, run);
+  const ordered =
+    preferred && bases.includes(preferred)
+      ? [preferred, ...bases.filter((candidate) => candidate !== preferred)]
+      : bases;
+
+  return [
+    ...ordered.map((base) => ({
+      label: `branch diff against ${base}`,
+      value: { worktree: repo, mode: "branch" as const, ref: `${base}...HEAD` },
+    })),
+  ];
+}
+
+function terminalIo(): { io: PickerIo; close: () => void } {
+  const readline = createInterface({ input: stdin, output: stdout });
+  return {
+    io: { write: (text) => stdout.write(text), ask: (prompt) => readline.question(prompt) },
+    close: () => readline.close(),
+  };
+}
+
+export interface PickerDeps {
+  rootFor: RepoRoot;
+  runnerFor: (repo: string) => Runner;
+  io: PickerIo;
+  openReview?: typeof openReviewTarget;
+}
+
+/** Selects a repository, review target and (when ambiguous) feedback agent. */
+export async function runReviewPicker(rt: Runtime, deps: PickerDeps): Promise<number> {
+  const repositories = discoverRepositories(
+    rt.herdr.paneList(rt.ctx.workspaceId),
+    rt.target.worktree,
+    deps.rootFor,
+  );
+  if (repositories.length === 0) {
+    return reportFailure(rt.herdr, "No Git repositories were found in this Herdr workspace.");
+  }
+
+  const repository = await chooseNumbered(
+    "Repository to review",
+    repositories.map((candidate) => ({
+      label: `${basename(candidate.worktree)} — ${candidate.worktree}`,
+      value: candidate,
+    })),
+    deps.io,
+  );
+  if (!repository) return 0;
+
+  const targets = targetChoices(repository.worktree, deps.runnerFor(repository.worktree));
+  if (targets.length === 0) {
+    return reportFailure(
+      rt.herdr,
+      `No base branches were found in ${repository.worktree}; review the working tree instead.`,
+    );
+  }
+  const target = await chooseNumbered(
+    `Changes to review in ${basename(repository.worktree)}`,
+    targets,
+    deps.io,
+  );
+  if (!target) return 0;
+
+  const agent = await chooseNumbered(
+    "Agent to receive review comments",
+    repository.agents.map((candidate) => ({ label: candidate.label, value: candidate })),
+    deps.io,
+  );
+
+  return (deps.openReview ?? openReviewTarget)(
+    "review:branch",
+    target,
+    target.ref,
+    rt,
+    agent ?? {},
+  );
+}
+
+/** Production wiring kept separate so selection logic remains testable without a TTY or Git. */
+export async function runTerminalReviewPicker(rt: Runtime): Promise<number> {
+  const terminal = terminalIo();
+  try {
+    return await runReviewPicker(rt, {
+      rootFor: (dir) => repoRoot(dir, realRunner(dir)),
+      runnerFor: realRunner,
+      io: terminal.io,
+    });
+  } finally {
+    terminal.close();
+  }
+}

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -4,12 +4,13 @@ import { stdin, stdout } from "node:process";
 import type { HerdrPane } from "./herdr.js";
 import { listBaseRefs, realRunner, repoRoot, resolveBaseRef, type Runner } from "./git.js";
 import { reportFailure } from "./herdr.js";
-import { openReviewTarget, type ReviewAssociation, type Runtime } from "./runtime.js";
+import { openReviewTarget, sendReviewTo, type ReviewAssociation, type Runtime } from "./runtime.js";
 import type { Target } from "./target.js";
 
 export interface AgentChoice extends ReviewAssociation {
   paneId: string;
   label: string;
+  worktree?: string;
 }
 
 export interface RepositoryChoice {
@@ -61,6 +62,34 @@ export function discoverRepositories(
     if (a.worktree === current) return -1;
     if (b.worktree === current) return 1;
     return a.worktree.localeCompare(b.worktree);
+  });
+}
+
+/** Lists every live agent in a workspace, with agents in the current repository first. */
+export function discoverAgents(
+  panes: HerdrPane[],
+  currentWorktree: string,
+  rootFor: RepoRoot,
+): AgentChoice[] {
+  const seen = new Set<string>();
+  const agents: AgentChoice[] = [];
+  for (const pane of panes) {
+    if (!pane.pane_id || !pane.agent || seen.has(pane.pane_id)) continue;
+    seen.add(pane.pane_id);
+    const worktree = rootFor(pane.foreground_cwd ?? pane.cwd ?? "") ?? undefined;
+    const name = pane.display_agent ?? pane.agent;
+    agents.push({
+      paneId: pane.pane_id,
+      agentPaneId: pane.pane_id,
+      agentName: name,
+      worktree,
+      label: `${name} (${pane.pane_id})${worktree ? ` — ${basename(worktree)}` : ""}`,
+    });
+  }
+  return agents.sort((a, b) => {
+    if (a.worktree === currentWorktree && b.worktree !== currentWorktree) return -1;
+    if (b.worktree === currentWorktree && a.worktree !== currentWorktree) return 1;
+    return a.label.localeCompare(b.label);
   });
 }
 
@@ -122,6 +151,12 @@ export interface PickerDeps {
   openReview?: typeof openReviewTarget;
 }
 
+export interface SendPickerDeps {
+  rootFor: RepoRoot;
+  io: PickerIo;
+  sendReview: (rt: Runtime, association: ReviewAssociation) => Promise<number>;
+}
+
 /** Selects a repository, review target and (when ambiguous) feedback agent. */
 export async function runReviewPicker(rt: Runtime, deps: PickerDeps): Promise<number> {
   const repositories = discoverRepositories(
@@ -180,6 +215,39 @@ export async function runTerminalReviewPicker(rt: Runtime): Promise<number> {
       rootFor: (dir) => repoRoot(dir, realRunner(dir)),
       runnerFor: realRunner,
       io: terminal.io,
+    });
+  } finally {
+    terminal.close();
+  }
+}
+
+/** Selects any live agent in the current workspace and delivers the open review to it. */
+export async function runSendReviewPicker(rt: Runtime, deps: SendPickerDeps): Promise<number> {
+  const agents = discoverAgents(
+    rt.herdr.paneList(rt.ctx.workspaceId),
+    rt.target.worktree,
+    deps.rootFor,
+  );
+  if (agents.length === 0) {
+    return reportFailure(rt.herdr, "No live agents were found in this Herdr workspace.");
+  }
+  const agent = await chooseNumbered(
+    "Agent to receive review comments",
+    agents.map((candidate) => ({ label: candidate.label, value: candidate })),
+    deps.io,
+  );
+  if (!agent) return 0;
+  return deps.sendReview(rt, agent);
+}
+
+/** Production wiring for the interactive send picker pane. */
+export async function runTerminalSendReviewPicker(rt: Runtime): Promise<number> {
+  const terminal = terminalIo();
+  try {
+    return await runSendReviewPicker(rt, {
+      rootFor: (dir) => repoRoot(dir, realRunner(dir)),
+      io: terminal.io,
+      sendReview: sendReviewTo,
     });
   } finally {
     terminal.close();

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -15,7 +15,9 @@ import {
   paneEntrypointFor,
   pickerEntrypointFor,
   PICK_REVIEW_ACTION,
+  PICK_SEND_ACTION,
   reviewRequestFor,
+  sendPickerEntrypointFor,
   type ReviewActionId,
 } from "./actions.js";
 import { DEFAULT_BINDINGS } from "./keys.js";
@@ -228,7 +230,7 @@ function commitRefFromContext(actionId: ReviewActionId, rt: Runtime): string | u
   return parsed?.ref;
 }
 
-async function sendReview(rt: Runtime): Promise<number> {
+export async function sendReviewTo(rt: Runtime, association?: ReviewAssociation): Promise<number> {
   const worktree = rt.target.worktree;
   let comments;
   try {
@@ -249,8 +251,8 @@ async function sendReview(rt: Runtime): Promise<number> {
   }
 
   const entry = rt.index.get(worktree);
-  const target = agentPaneFromContext(rt) ?? entry?.agentPaneId;
-  const label = rt.ctx.agentName ?? entry?.agentName;
+  const target = association?.agentPaneId ?? agentPaneFromContext(rt) ?? entry?.agentPaneId;
+  const label = association?.agentName ?? rt.ctx.agentName ?? entry?.agentName;
   if (!target) {
     return reportFailure(rt.herdr, "No agent is associated with this worktree; comments kept.");
   }
@@ -258,6 +260,10 @@ async function sendReview(rt: Runtime): Promise<number> {
   const text = formatReview(unsent, worktree, rt.cfg, label);
   if (!rt.herdr.promptAgent(target, text)) {
     return reportFailure(rt.herdr, `Could not prompt agent "${label ?? target}"; comments kept.`);
+  }
+
+  if (association?.agentName || association?.agentPaneId) {
+    rt.index.upsert({ worktree, ...association, sent: [] });
   }
 
   // Record delivery before cleanup so a removal failure cannot cause a duplicate prompt.
@@ -318,11 +324,26 @@ export async function dispatch(actionId: string, rt: Runtime): Promise<number> {
             "Check `herdr plugin log list` for the failure.",
         );
   }
+  if (actionId === PICK_SEND_ACTION) {
+    const entrypoint = sendPickerEntrypointFor();
+    const paneId = rt.herdr.openPane({
+      entrypoint,
+      cwd: rt.target.worktree,
+      placement: "overlay",
+    });
+    return paneId
+      ? 0
+      : reportFailure(
+          rt.herdr,
+          `Could not open the agent picker (entrypoint "${entrypoint}"). ` +
+            "Check `herdr plugin log list` for the failure.",
+        );
+  }
   if (isReviewAction(actionId)) return reviewAction(actionId, rt);
 
   switch (actionId) {
     case "send-review":
-      return sendReview(rt);
+      return sendReviewTo(rt);
     case "reload": {
       // Reload the displayed mode, falling back to config only when no mode was recorded.
       const recorded = rt.index.get(rt.target.worktree);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13,6 +13,8 @@ import { commitExists, hasCommitsAhead, realRunner, repoRoot, resolveBaseRef } f
 import {
   isReviewAction,
   paneEntrypointFor,
+  pickerEntrypointFor,
+  PICK_REVIEW_ACTION,
   reviewRequestFor,
   type ReviewActionId,
 } from "./actions.js";
@@ -26,7 +28,10 @@ export interface Runtime {
   /** Shared directory for the review index and note sidecars. */
   stateDir: string;
   index: ReviewIndex;
-  herdr: Pick<HerdrAdapter, "notify" | "promptAgent" | "openPane" | "closePane" | "reportMetadata">;
+  herdr: Pick<
+    HerdrAdapter,
+    "notify" | "promptAgent" | "openPane" | "closePane" | "reportMetadata" | "paneList"
+  >;
   hunk: Pick<HunkAdapter, "listComments" | "removeComment" | "reload" | "navigate">;
   /** Config-driven target, equivalent to `targetFor()`. */
   target: Target;
@@ -107,22 +112,41 @@ function displayedReviewRecord(
   };
 }
 
-/** Opens or re-points a review using the mode encoded by its action id. */
-async function reviewAction(actionId: ReviewActionId, rt: Runtime): Promise<number> {
-  const request = reviewRequestFor(actionId);
+export interface ReviewAssociation {
+  agentName?: string;
+  agentPaneId?: string;
+}
 
-  const suppliedRef = commitRefFromContext(actionId, rt);
+function associationFromContext(rt: Runtime): ReviewAssociation {
+  return { agentName: rt.ctx.agentName, agentPaneId: agentPaneFromContext(rt) };
+}
 
-  const target = rt.targetFor(request.mode, suppliedRef);
+/** Opens or re-points a review whose repository and ref have already been resolved. */
+export async function openReviewTarget(
+  actionId: ReviewActionId,
+  target: Target,
+  suppliedRef: string | undefined,
+  rt: Runtime,
+  association: ReviewAssociation = associationFromContext(rt),
+): Promise<number> {
   if (target.warning) rt.herdr.notify(target.warning);
 
   // hunk writes its own failure into a pane herdr then tears down, so the message never lands.
-  if (suppliedRef !== undefined && !rt.commitExists(target.worktree, suppliedRef)) {
+  if (
+    target.mode === "commit" &&
+    suppliedRef !== undefined &&
+    !rt.commitExists(target.worktree, suppliedRef)
+  ) {
     return reportFailure(
       rt.herdr,
       `Could not resolve ${suppliedRef} in ${target.worktree}. ` +
         "Fetch the commit, then try the link again.",
     );
+  }
+
+  // Explicit picker choices must update the round-trip destination even when a pane is reused.
+  if (association.agentName || association.agentPaneId) {
+    rt.index.upsert({ worktree: target.worktree, ...association, sent: [] });
   }
 
   const existing = rt.index.get(target.worktree);
@@ -150,8 +174,7 @@ async function reviewAction(actionId: ReviewActionId, rt: Runtime): Promise<numb
   // Herdr starts the pane process during openPane, so its launch state must already be persisted.
   rt.index.upsert({
     worktree: target.worktree,
-    agentName: rt.ctx.agentName,
-    agentPaneId: agentPaneFromContext(rt),
+    ...association,
     ...displayedReviewRecord(target, suppliedRef),
     sent: [],
   });
@@ -174,6 +197,16 @@ async function reviewAction(actionId: ReviewActionId, rt: Runtime): Promise<numb
   rt.index.upsert({ worktree: target.worktree, paneId, sent: [] });
   await reportReviewMetadata(rt, target);
   return 0;
+}
+
+/** Opens or re-points a review using the mode encoded by its action id. */
+async function reviewAction(actionId: ReviewActionId, rt: Runtime): Promise<number> {
+  const request = reviewRequestFor(actionId);
+
+  const suppliedRef = commitRefFromContext(actionId, rt);
+
+  const target = rt.targetFor(request.mode, suppliedRef);
+  return openReviewTarget(actionId, target, suppliedRef, rt);
 }
 
 /** Returns the invoking pane only when Herdr reports that it runs an agent. */
@@ -270,6 +303,21 @@ async function navigateAction(
 }
 
 export async function dispatch(actionId: string, rt: Runtime): Promise<number> {
+  if (actionId === PICK_REVIEW_ACTION) {
+    const entrypoint = pickerEntrypointFor();
+    const paneId = rt.herdr.openPane({
+      entrypoint,
+      cwd: rt.target.worktree,
+      placement: "overlay",
+    });
+    return paneId
+      ? 0
+      : reportFailure(
+          rt.herdr,
+          `Could not open the review picker (entrypoint "${entrypoint}"). ` +
+            "Check `herdr plugin log list` for the failure.",
+        );
+  }
   if (isReviewAction(actionId)) return reviewAction(actionId, rt);
 
   switch (actionId) {

--- a/tests/herdr.test.ts
+++ b/tests/herdr.test.ts
@@ -139,6 +139,57 @@ describe("HerdrAdapter", () => {
     expect(wrongField.agentList()).toEqual([]);
   });
 
+  it("lists panes in one workspace with cwd and agent fields", () => {
+    const calls: string[][] = [];
+    const herdr = new HerdrAdapter("herdr", (args) => {
+      calls.push(args);
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          result: {
+            panes: [
+              {
+                pane_id: "w1:p1",
+                workspace_id: "w1",
+                cwd: "/repo",
+                foreground_cwd: "/repo/src",
+                agent: "claude",
+                display_agent: "api",
+              },
+              null,
+              { pane_id: 42, cwd: false },
+            ],
+          },
+        }),
+      };
+    });
+
+    expect(herdr.paneList("w1")).toEqual([
+      {
+        pane_id: "w1:p1",
+        workspace_id: "w1",
+        cwd: "/repo",
+        foreground_cwd: "/repo/src",
+        agent: "claude",
+        display_agent: "api",
+      },
+      {
+        pane_id: undefined,
+        workspace_id: undefined,
+        cwd: undefined,
+        foreground_cwd: undefined,
+        agent: undefined,
+        display_agent: undefined,
+      },
+    ]);
+    expect(calls[0]).toEqual(["pane", "list", "--workspace", "w1"]);
+  });
+
+  it("returns no panes when pane-list JSON has an unexpected shape", () => {
+    const herdr = new HerdrAdapter("herdr", () => ({ status: 0, stdout: "{}" }));
+    expect(herdr.paneList()).toEqual([]);
+  });
+
   it("reports pane metadata with the pane id FIRST and a plugin-scoped source", () => {
     const calls: string[][] = [];
     const herdr = new HerdrAdapter("herdr", (args) => {

--- a/tests/keys-install.test.ts
+++ b/tests/keys-install.test.ts
@@ -167,6 +167,7 @@ describe("installKeys", () => {
       "prefix+shift+s",
       "prefix+shift+c",
       "prefix+shift+a",
+      "prefix+alt+h",
     ]);
     expect(res.skipped!.map((b) => b.key)).toEqual(["prefix+shift+h"]);
 
@@ -177,7 +178,7 @@ describe("installKeys", () => {
 
   it("names each skipped key and the action it would have bound, so it can be rebound by hand", () => {
     const res = installKeys(config(COLLIDING), DEFAULT_BINDINGS);
-    expect(res.message).toContain("Installed 3 of 4 keybinding(s)");
+    expect(res.message).toContain("Installed 4 of 5 keybinding(s)");
     expect(res.message).toContain("prefix+shift+h");
     expect(res.message).toContain("jhochenbaum.hunkdiff.review");
     expect(res.message).toContain("already bound");

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -158,12 +158,13 @@ describe("takenKeys", () => {
 });
 
 describe("DEFAULT_BINDINGS", () => {
-  it("binds the four motions common enough to earn a default key", () => {
+  it("binds the five motions common enough to earn a default key", () => {
     expect(DEFAULT_BINDINGS.map((b) => [b.key, b.action])).toEqual([
       ["prefix+shift+h", "jhochenbaum.hunkdiff.review"],
       ["prefix+shift+s", "jhochenbaum.hunkdiff.send-review"],
       ["prefix+shift+c", "jhochenbaum.hunkdiff.review:commit"],
       ["prefix+shift+a", "jhochenbaum.hunkdiff.review:staged"],
+      ["prefix+alt+h", "jhochenbaum.hunkdiff.review:pick"],
     ]);
   });
 

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -5,6 +5,7 @@ import {
   paneEntrypointFor,
   pickerEntrypointFor,
   REVIEW_ACTIONS,
+  sendPickerEntrypointFor,
   WINDOWS_PANE_SUFFIX,
   type ReviewActionId,
 } from "../src/actions.js";
@@ -52,6 +53,7 @@ describe("herdr-plugin.toml", () => {
       "review:stash": ["workspace"],
       "review:pick": ["workspace", "pane"],
       "send-review": ["pane"],
+      "send-review:pick": ["workspace", "pane"],
       reload: ["workspace", "pane"],
       "close-review": ["pane", "workspace"],
       "setup-keys": ["workspace"],
@@ -147,6 +149,8 @@ describe("herdr-plugin.toml", () => {
             ...entrypoints(),
             pickerEntrypointFor("darwin"),
             pickerEntrypointFor("win32"),
+            sendPickerEntrypointFor("darwin"),
+            sendPickerEntrypointFor("win32"),
           ]),
         ].sort(),
       );

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { parse } from "smol-toml";
 import {
   paneEntrypointFor,
+  pickerEntrypointFor,
   REVIEW_ACTIONS,
   WINDOWS_PANE_SUFFIX,
   type ReviewActionId,
@@ -49,6 +50,7 @@ describe("herdr-plugin.toml", () => {
       "review:branch": ["workspace", "pane"],
       "review:commit": ["workspace"],
       "review:stash": ["workspace"],
+      "review:pick": ["workspace", "pane"],
       "send-review": ["pane"],
       reload: ["workspace", "pane"],
       "close-review": ["pane", "workspace"],
@@ -140,7 +142,13 @@ describe("herdr-plugin.toml", () => {
 
     it("declares exactly the panes the review actions open, and no others", () => {
       expect(manifest.panes.map((p: any) => p.id).sort()).toEqual(
-        [...new Set(entrypoints())].sort(),
+        [
+          ...new Set([
+            ...entrypoints(),
+            pickerEntrypointFor("darwin"),
+            pickerEntrypointFor("win32"),
+          ]),
+        ].sort(),
       );
     });
 

--- a/tests/picker.test.ts
+++ b/tests/picker.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   chooseNumbered,
+  discoverAgents,
   discoverRepositories,
   runReviewPicker,
+  runSendReviewPicker,
   targetChoices,
   type PickerIo,
 } from "../src/picker.js";
@@ -70,6 +72,28 @@ describe("discoverRepositories", () => {
         ],
       },
     ]);
+  });
+});
+
+describe("discoverAgents", () => {
+  const rootFor = (dir: string) => {
+    if (dir.startsWith("/repo-a")) return "/repo-a";
+    if (dir.startsWith("/repo-b")) return "/repo-b";
+    return null;
+  };
+
+  it("lists all workspace agents and puts the current repository first", () => {
+    expect(
+      discoverAgents(
+        [
+          { pane_id: "w1:p1", cwd: "/repo-a", agent: "claude" },
+          { pane_id: "w1:p2", cwd: "/repo-b", agent: "codex", display_agent: "backend" },
+          { pane_id: "w1:p3", cwd: "/tmp" },
+        ],
+        "/repo-b",
+        rootFor,
+      ).map((agent) => agent.paneId),
+    ).toEqual(["w1:p2", "w1:p1"]);
   });
 });
 
@@ -205,5 +229,51 @@ describe("runReviewPicker", () => {
       }),
     ).toBe(1);
     expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringMatching(/no git repositories/i));
+  });
+});
+
+describe("runSendReviewPicker", () => {
+  it("sends the current review to the selected workspace agent", async () => {
+    const sendReview = vi.fn(async () => 0);
+    const rt = {
+      ctx: { workspaceId: "w1" },
+      target: { worktree: "/repo-a", mode: "working" },
+      herdr: {
+        paneList: vi.fn(() => [
+          { pane_id: "w1:p1", cwd: "/repo-a", agent: "claude" },
+          { pane_id: "w1:p2", cwd: "/repo-b", agent: "codex", display_agent: "backend" },
+        ]),
+        notify: vi.fn(),
+      },
+    } as any;
+    const rootFor = (dir: string) => (dir.startsWith("/repo-") ? dir : null);
+
+    expect(
+      await runSendReviewPicker(rt, {
+        rootFor,
+        io: scriptedIo("2"),
+        sendReview,
+      }),
+    ).toBe(0);
+    expect(sendReview).toHaveBeenCalledWith(
+      rt,
+      expect.objectContaining({ agentName: "backend", agentPaneId: "w1:p2" }),
+    );
+  });
+
+  it("fails visibly when no live agent exists in the workspace", async () => {
+    const rt = {
+      ctx: { workspaceId: "w1" },
+      target: { worktree: "/repo-a", mode: "working" },
+      herdr: { paneList: () => [{ cwd: "/repo-a" }], notify: vi.fn() },
+    } as any;
+    expect(
+      await runSendReviewPicker(rt, {
+        rootFor: () => "/repo-a",
+        io: scriptedIo(),
+        sendReview: vi.fn(),
+      }),
+    ).toBe(1);
+    expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringMatching(/no live agents/i));
   });
 });

--- a/tests/picker.test.ts
+++ b/tests/picker.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  chooseNumbered,
+  discoverRepositories,
+  runReviewPicker,
+  targetChoices,
+  type PickerIo,
+} from "../src/picker.js";
+
+function scriptedIo(...answers: string[]): PickerIo & { output: string } {
+  const state = {
+    output: "",
+    write(text: string) {
+      state.output += text;
+    },
+    async ask(prompt: string) {
+      state.output += prompt;
+      return answers.shift() ?? "q";
+    },
+  };
+  return state;
+}
+
+describe("discoverRepositories", () => {
+  const rootFor = (dir: string) => {
+    if (dir.startsWith("/repo-a")) return "/repo-a";
+    if (dir.startsWith("/repo-b")) return "/repo-b";
+    return null;
+  };
+
+  it("groups Git roots from all panes and keeps the current repository first", () => {
+    expect(
+      discoverRepositories(
+        [
+          { pane_id: "w1:p1", cwd: "/repo-a", agent: "claude" },
+          {
+            pane_id: "w1:p2",
+            cwd: "/repo-a",
+            foreground_cwd: "/repo-b/services/api",
+            agent: "codex",
+            display_agent: "backend",
+          },
+          { pane_id: "w1:p3", cwd: "/repo-b/docs" },
+          { pane_id: "w1:p4", cwd: "/tmp" },
+        ],
+        "/repo-b",
+        rootFor,
+      ),
+    ).toEqual([
+      {
+        worktree: "/repo-b",
+        agents: [
+          {
+            paneId: "w1:p2",
+            agentPaneId: "w1:p2",
+            agentName: "backend",
+            label: "backend (w1:p2)",
+          },
+        ],
+      },
+      {
+        worktree: "/repo-a",
+        agents: [
+          {
+            paneId: "w1:p1",
+            agentPaneId: "w1:p1",
+            agentName: "claude",
+            label: "claude (w1:p1)",
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe("chooseNumbered", () => {
+  it("re-prompts after invalid input and returns the chosen value", async () => {
+    const io = scriptedIo("nope", "2");
+    expect(
+      await chooseNumbered(
+        "Pick",
+        [
+          { label: "first", value: "a" },
+          { label: "second", value: "b" },
+        ],
+        io,
+      ),
+    ).toBe("b");
+    expect(io.output).toContain("Enter one of the listed numbers");
+  });
+
+  it("returns undefined when the user cancels", async () => {
+    expect(
+      await chooseNumbered(
+        "Pick",
+        [
+          { label: "first", value: "a" },
+          { label: "second", value: "b" },
+        ],
+        scriptedIo("q"),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("selects a sole choice without prompting", async () => {
+    const io = { write: vi.fn(), ask: vi.fn() };
+    expect(await chooseNumbered("Pick", [{ label: "only", value: 7 }], io)).toBe(7);
+    expect(io.ask).not.toHaveBeenCalled();
+  });
+});
+
+describe("targetChoices", () => {
+  it("puts Git's resolved base first and excludes symbolic and current-branch refs", () => {
+    const run = vi.fn((_cmd: string, args: string[]) => {
+      if (args[0] === "for-each-ref") {
+        return {
+          status: 0,
+          stdout:
+            "feature\t\nmain\t\norigin/feature\t\norigin/main\t\norigin/release\t\norigin/HEAD\trefs/remotes/origin/main\n",
+        };
+      }
+      if (args[0] === "symbolic-ref" && args.includes("HEAD")) {
+        return { status: 0, stdout: "feature\n" };
+      }
+      if (args.includes("@{u}")) return { status: 0, stdout: "origin/main\n" };
+      return { status: 1, stdout: "" };
+    });
+
+    expect(targetChoices("/repo", run)).toEqual([
+      {
+        label: "branch diff against origin/main",
+        value: { worktree: "/repo", mode: "branch", ref: "origin/main...HEAD" },
+      },
+      {
+        label: "branch diff against main",
+        value: { worktree: "/repo", mode: "branch", ref: "main...HEAD" },
+      },
+      {
+        label: "branch diff against origin/release",
+        value: { worktree: "/repo", mode: "branch", ref: "origin/release...HEAD" },
+      },
+    ]);
+  });
+});
+
+describe("runReviewPicker", () => {
+  it("opens the selected repository/base and associates its agent for round-trip comments", async () => {
+    const openReview = vi.fn(async () => 0);
+    const rt = {
+      ctx: { workspaceId: "w1" },
+      target: { worktree: "/repo-a", mode: "working" },
+      herdr: {
+        paneList: vi.fn(() => [
+          { pane_id: "w1:p1", cwd: "/repo-a", agent: "claude" },
+          { pane_id: "w1:p2", cwd: "/repo-b", agent: "codex", display_agent: "backend" },
+        ]),
+        notify: vi.fn(),
+      },
+    } as any;
+    const rootFor = (dir: string) =>
+      dir.startsWith("/repo-") ? dir.split("/").slice(0, 2).join("/") : null;
+    const runnerFor = () => (_cmd: string, args: string[]) => {
+      if (args[0] === "for-each-ref") return { status: 0, stdout: "main\t\n" };
+      if (args[0] === "symbolic-ref" && args.includes("HEAD")) {
+        return { status: 0, stdout: "feature\n" };
+      }
+      if (args.includes("@{u}")) return { status: 1, stdout: "" };
+      if (args[0] === "symbolic-ref") return { status: 1, stdout: "" };
+      if (args[0] === "rev-parse" && args.at(-1) === "main") {
+        return { status: 0, stdout: "abc\n" };
+      }
+      return { status: 1, stdout: "" };
+    };
+
+    expect(
+      await runReviewPicker(rt, {
+        rootFor,
+        runnerFor,
+        io: scriptedIo("2"),
+        openReview,
+      }),
+    ).toBe(0);
+    expect(rt.herdr.paneList).toHaveBeenCalledWith("w1");
+    expect(openReview).toHaveBeenCalledWith(
+      "review:branch",
+      { worktree: "/repo-b", mode: "branch", ref: "main...HEAD" },
+      "main...HEAD",
+      rt,
+      expect.objectContaining({ agentName: "backend", agentPaneId: "w1:p2" }),
+    );
+  });
+
+  it("fails visibly when the workspace contains no Git repository", async () => {
+    const rt = {
+      ctx: { workspaceId: "w1" },
+      target: { worktree: "/tmp", mode: "working" },
+      herdr: { paneList: () => [{ cwd: "/tmp" }], notify: vi.fn() },
+    } as any;
+    expect(
+      await runReviewPicker(rt, {
+        rootFor: () => null,
+        runnerFor: vi.fn(),
+        io: scriptedIo(),
+        openReview: vi.fn(),
+      }),
+    ).toBe(1);
+    expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringMatching(/no git repositories/i));
+  });
+});

--- a/tests/runtime-actions.test.ts
+++ b/tests/runtime-actions.test.ts
@@ -2,10 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { paneEntrypointFor, pickerEntrypointFor } from "../src/actions.js";
+import { paneEntrypointFor, pickerEntrypointFor, sendPickerEntrypointFor } from "../src/actions.js";
 import { DEFAULTS } from "../src/config.js";
 import { DEFAULT_BINDINGS } from "../src/keys.js";
-import { dispatch, openReviewTarget } from "../src/runtime.js";
+import { dispatch, openReviewTarget, sendReviewTo } from "../src/runtime.js";
 import { ReviewIndex } from "../src/index-store.js";
 import { HunkUnavailableError } from "../src/hunk.js";
 
@@ -58,6 +58,31 @@ describe("review picker", () => {
     });
     expect(await dispatch("review:pick", rt as any)).toBe(1);
     expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringMatching(/review picker/i));
+  });
+});
+
+describe("send picker", () => {
+  it("opens a temporary agent picker in the current repository", async () => {
+    const rt = runtime();
+    expect(await dispatch("send-review:pick", rt as any)).toBe(0);
+    expect(rt.herdr.openPane).toHaveBeenCalledWith({
+      entrypoint: sendPickerEntrypointFor(),
+      cwd: "/wt/x",
+      placement: "overlay",
+    });
+  });
+
+  it("reports when Herdr cannot open the agent picker pane", async () => {
+    const rt = runtime({
+      herdr: {
+        notify: vi.fn(),
+        promptAgent: vi.fn(() => true),
+        openPane: vi.fn(() => null),
+        closePane: vi.fn(() => true),
+      },
+    });
+    expect(await dispatch("send-review:pick", rt as any)).toBe(1);
+    expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringMatching(/agent picker/i));
   });
 });
 
@@ -332,6 +357,40 @@ describe("pane metadata reporting", () => {
     expect(reportMetadata).toHaveBeenCalledWith("w1:p7", {
       title: "Review: x",
       display_agent: "hunk",
+    });
+  });
+
+  it("sends to an explicitly selected agent and remembers it for later rounds", async () => {
+    const promptAgent = vi.fn(() => true);
+    const rt = runtime({
+      ctx: { worktree: "/wt/x", workspaceId: "w1", paneId: "w1:p7" },
+      herdr: {
+        notify: vi.fn(),
+        promptAgent,
+        openPane: vi.fn(() => "w1:p7"),
+        closePane: vi.fn(() => true),
+      },
+      hunk: {
+        listComments: vi.fn(async () => [
+          { noteId: "c1", filePath: "src/a.ts", newRange: [3, 3], body: "Fix" },
+        ]),
+        removeComment: vi.fn(async () => {}),
+        reload: vi.fn(async () => {}),
+        navigate: vi.fn(async () => {}),
+      },
+    });
+
+    expect(
+      await sendReviewTo(rt as any, {
+        agentName: "backend",
+        agentPaneId: "w1:p9",
+      }),
+    ).toBe(0);
+    expect(promptAgent).toHaveBeenCalledWith("w1:p9", expect.stringContaining("Fix"));
+    expect(rt.index.get("/wt/x")).toMatchObject({
+      agentName: "backend",
+      agentPaneId: "w1:p9",
+      sent: ["c1"],
     });
   });
 

--- a/tests/runtime-actions.test.ts
+++ b/tests/runtime-actions.test.ts
@@ -2,10 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { paneEntrypointFor } from "../src/actions.js";
+import { paneEntrypointFor, pickerEntrypointFor } from "../src/actions.js";
 import { DEFAULTS } from "../src/config.js";
 import { DEFAULT_BINDINGS } from "../src/keys.js";
-import { dispatch } from "../src/runtime.js";
+import { dispatch, openReviewTarget } from "../src/runtime.js";
 import { ReviewIndex } from "../src/index-store.js";
 import { HunkUnavailableError } from "../src/hunk.js";
 
@@ -36,7 +36,57 @@ function runtime(over: Record<string, any> = {}) {
   return rt;
 }
 
+describe("review picker", () => {
+  it("opens a temporary overlay in the current repository", async () => {
+    const rt = runtime();
+    expect(await dispatch("review:pick", rt as any)).toBe(0);
+    expect(rt.herdr.openPane).toHaveBeenCalledWith({
+      entrypoint: pickerEntrypointFor(),
+      cwd: "/wt/x",
+      placement: "overlay",
+    });
+  });
+
+  it("reports when Herdr cannot open the picker pane", async () => {
+    const rt = runtime({
+      herdr: {
+        notify: vi.fn(),
+        promptAgent: vi.fn(() => true),
+        openPane: vi.fn(() => null),
+        closePane: vi.fn(() => true),
+      },
+    });
+    expect(await dispatch("review:pick", rt as any)).toBe(1);
+    expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringMatching(/review picker/i));
+  });
+});
+
 describe("reuse_pane", () => {
+  it("updates the round-trip agent when an explicit repository selection reuses a pane", async () => {
+    const rt = runtime();
+    rt.index.upsert({
+      worktree: "/wt/x",
+      paneId: "w1:p7",
+      agentName: "old-agent",
+      agentPaneId: "w1:p1",
+      sent: [],
+    });
+    expect(
+      await openReviewTarget(
+        "review:branch",
+        { worktree: "/wt/x", mode: "branch", ref: "origin/main...HEAD" },
+        "origin/main...HEAD",
+        rt as any,
+        { agentName: "backend", agentPaneId: "w1:p9" },
+      ),
+    ).toBe(0);
+    expect(rt.index.get("/wt/x")).toMatchObject({
+      agentName: "backend",
+      agentPaneId: "w1:p9",
+      paneId: "w1:p7",
+    });
+  });
+
   it("reloads an existing review instead of opening a second pane", async () => {
     const rt = runtime();
     rt.index.upsert({ worktree: "/wt/x", paneId: "w1:p7", sent: [] });
@@ -524,7 +574,7 @@ describe("setup-keys reporting", () => {
 
     expect(code).toBe(0);
     expect(rt.herdr.notify).toHaveBeenCalledWith(
-      expect.stringContaining("Installed 4 keybinding(s)"),
+      expect.stringContaining("Installed 5 keybinding(s)"),
     );
     expect(readFileSync(override, "utf8")).toContain("jhochenbaum.hunkdiff.review");
     expect(readFileSync(defaultConfigPath(fakeHome), "utf8")).toBe(userBinding("prefix+shift+h"));
@@ -542,7 +592,7 @@ describe("setup-keys reporting", () => {
     );
 
     expect(code).toBe(0);
-    expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringContaining("Installed 3 of 4"));
+    expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringContaining("Installed 4 of 5"));
     expect(readFileSync(override, "utf8")).toContain(userBinding("prefix+shift+h"));
   });
 
@@ -578,7 +628,7 @@ describe("setup-keys reporting", () => {
     expect(rt.herdr.notify).toHaveBeenCalledWith(
       expect.stringContaining("prefix+shift+h (jhochenbaum.hunkdiff.review)"),
     );
-    expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringContaining("Installed 3 of 4"));
+    expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringContaining("Installed 4 of 5"));
   });
 
   it("exits 1 and says nothing was installed when every key collided", async () => {
@@ -587,6 +637,6 @@ describe("setup-keys reporting", () => {
     const code = await dispatchWithHome(homeWithConfig(allTaken), rt);
 
     expect(code).toBe(1);
-    expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringContaining("Installed 0 of 4"));
+    expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringContaining("Installed 0 of 5"));
   });
 });


### PR DESCRIPTION
## Problem

A Herdr workspace can contain agent panes from several Git repositories, especially when a top-level project is composed of multiple checkouts. The existing review actions intentionally follow the focused pane, but that makes it easy to review the wrong repository/base or send comments to the wrong agent when several repositories are active.

## Changes

- add `review:pick` for explicit repository, base branch, and feedback-agent selection
- add `send-review:pick` so an open review can be sent to any live agent selected at delivery time
- discover Git worktrees and agents from every pane in the current Herdr workspace, preferring each pane's foreground cwd
- open Hunk with an explicit `<base>...HEAD` range and persist the chosen agent association for later `send-review`
- use dependency-free numbered overlay pickers, including POSIX and Windows pane entries
- preserve the existing focus-based review actions unchanged
- document the workflows and cover discovery, selection, branch refs, pane reuse, delivery, association, manifest, and keys with tests

The new send-time picker has no plugin-wide default key because likely `prefix+alt+...` candidates can collide with Herdr defaults. Users with a freed key can bind `jhochenbaum.hunkdiff.send-review:pick` explicitly.

## Validation

- `npm run check`
- `npm run build`
- `npm test` (28 files, 686 tests)
- `npm audit --audit-level=high --registry=https://registry.npmjs.org/` (0 vulnerabilities)
- installed the branch as a real Herdr plugin and invoked `review:pick` successfully

Related to #15: the picker makes the comparison base explicit instead of assuming a single repository/base for the whole workspace.
