### PR TITLE
chore(release): prepare 0.2.1

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "jhochenbaum.hunkdiff"
 name = "hunk"
-version = "0.2.0"
+version = "0.2.1"
 
 # Requires plugin-root-relative action commands and reliable agent prompt submission from Herdr 0.8.
 min_herdr_version = "0.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "herdr-hunk-diff",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herdr-hunk-diff",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "hunkdiff": "0.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herdr-hunk-diff",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A herdr plugin that reviews agent-authored diffs in hunk and sends your inline comments back to the agent that wrote them.",
   "license": "MIT",
   "author": "Jordan Hochenbaum",


### PR DESCRIPTION
Patch release for the dependency updates on main. The plugin's own surface is unchanged.

The reason to tag: `hunkdiff` moves 0.19.0 → 0.20.1 (#19), which rejects option-like Git ranges and refs in session reloads — an upstream fix for a path where a broker caller could inject Git flags and write diff output to arbitrary paths. v0.2.0's release notes still advertise 0.19.0, so the latest release doesn't tell you the hardened hunk is what installs.

No plugin change was needed for the stricter ref parsing: `buildLaunchArgs` passes only git-derived refs as positionals (base branch, commit SHA, `stash@{0}`), and `canReload` already excludes stash from `session reload`.

Also included, both dev-only: `typescript-eslint` 8.68.0 (#18) and `vitest` 5.0.0 (#17). Note that Dependabot's rebase retargeted #17 from the 4.1.11 patch in its title to the 5.0.0 major, leaving its metadata claiming a patch. Kept after verifying, not merged as a patch by mistake.

`min_herdr_version` stays at 0.8.0.

## Validation

- `.github/verified-hunk-version` synced to 0.20.1, which runs check/build/test on main before recording the marker
- `npm run check`, `npm run build`, `npm test` (27 files, 668 tests) pass on this branch
