### PR TITLE
feat: configure review bases and display active targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://github.com/user-attachments/assets/a36991a9-288f-4c8a-845c-ce2399334b9b
 - [Requirements](#requirements)
 - [Quick start](#quick-start)
 - [Keybinding behavior](#keybinding-behavior)
-- [Review actions](#review-actions) &middot; [Base branch resolution](#base-branch-resolution) &middot; [GitHub commit links](#github-commit-links)
+- [Review actions](#review-actions) &middot; [Base branch resolution](#base-branch-resolution) &middot; [Which diff am I looking at?](#which-diff-am-i-looking-at) &middot; [GitHub commit links](#github-commit-links)
 - [Configuration](#configuration) &middot; [Options](#option-reference) &middot; [Automatic opening](#automatic-opening) &middot; [Target and display](#review-target-and-display) &middot; [Round-trip prompts](#round-trip-prompts) &middot; [Hunk executable](#hunk-executable)
 - [Optional VCS pager setup](#optional-vcs-pager-setup)
 - [Direct hunk workflows](#direct-hunk-workflows)
@@ -139,13 +139,13 @@ herdr server reload-config
 
 **Opening a review**
 
-| Action          | Review opened                                                                                              |
-| --------------- | ---------------------------------------------------------------------------------------------------------- |
-| `review`        | Configured `default_target`; `auto` selects the branch diff when ahead of base, otherwise the working tree |
-| `review:staged` | Staged changes with `hunk diff --staged`                                                                   |
-| `review:branch` | `<base>...HEAD`; falls back to the working tree with a warning when no base can be resolved                |
-| `review:commit` | The latest commit, or a locally available commit from a Ctrl-clicked GitHub commit URL                     |
-| `review:stash`  | The most recent stash entry                                                                                |
+| Action          | Review opened                                                                                            |
+| --------------- | -------------------------------------------------------------------------------------------------------- |
+| `review`        | Configured `default_target`; `auto` shows uncommitted changes, or the branch diff when the tree is clean |
+| `review:staged` | Staged changes with `hunk diff --staged`                                                                 |
+| `review:branch` | `<base>...HEAD`; falls back to the working tree with a warning when no base can be resolved              |
+| `review:commit` | The latest commit, or a locally available commit from a Ctrl-clicked GitHub commit URL                   |
+| `review:stash`  | The most recent stash entry                                                                              |
 
 **Everything else**
 
@@ -171,12 +171,31 @@ herdr plugin action invoke <action> --plugin jhochenbaum.hunkdiff
 
 Branch reviews resolve their base in this order:
 
-1. The current branch's upstream, unless it is that branch's own remote-tracking branch
-2. `origin/HEAD`
-3. The first existing branch named `main`, `master`, or `trunk`
+1. `review.base`, when set and the ref exists
+2. The current branch's upstream, unless it is that branch's own remote-tracking branch
+3. `origin/HEAD`
+4. The first existing branch named `main`, `master`, or `trunk`
 
-This keeps a feature branch that deliberately tracks `origin/main` working as expected while
-avoiding an empty comparison against `origin/<same-feature-branch>`.
+Steps 2-4 keep a feature branch that deliberately tracks `origin/main` working as expected while
+avoiding an empty comparison against `origin/<same-feature-branch>`. They also mean a branch cut
+from something other than the repository's default branch resolves to that default rather than to
+the branch it was actually cut from, because Git does not record where a branch came from. Set
+`review.base` when you want a different base:
+
+```toml
+[review]
+base = "origin/develop"
+```
+
+A `review.base` that does not exist is reported, and the review falls back to detection rather
+than handing Hunk a range it cannot resolve. An explicit range passed to `review:branch` still
+wins over both.
+
+### Which diff am I looking at?
+
+The review pane's title names the resolved target — `Review: my-repo — origin/main...HEAD`,
+`Review: my-repo — working tree`, `Review: my-repo — staged`, `Review: my-repo — commit abc1234`
+— so `auto` never leaves the comparison a guess.
 
 ### GitHub commit links
 
@@ -205,6 +224,7 @@ auto_open         = false
 on_states         = ["idle"]  # idle | working | blocked | unknown
 reuse_pane        = true
 default_target    = "auto"    # auto | working | staged | branch
+base              = ""        # branch reviews compare against this ref; empty detects one
 watch             = false
 placement         = "split"   # overlay | split | tab | zoomed
 exclude_untracked = false
@@ -228,15 +248,16 @@ extra_args   = []
 <details>
 <summary><b><code>[review]</code></b> — what opens, where, and when</summary>
 
-| Setting                    | Accepted values                                 | Effect                                                                                                                     |
-| -------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `review.auto_open`         | `true` / `false`                                | Opens or refreshes a review when an associated agent enters a configured state.                                            |
-| `review.on_states`         | List of `idle`, `working`, `blocked`, `unknown` | Selects the Herdr agent states that trigger automatic opening. An empty list disables all triggers.                        |
-| `review.reuse_pane`        | `true` / `false`                                | Refreshes the worktree's existing review pane when possible instead of opening another pane.                               |
-| `review.default_target`    | `auto`, `working`, `staged`, `branch`           | Chooses what the `review` action shows. `auto` uses the branch diff when ahead of its base and the working tree otherwise. |
-| `review.watch`             | `true` / `false`                                | Passes `--watch` to Hunk so an open review refreshes as its underlying source changes.                                     |
-| `review.placement`         | `overlay`, `split`, `tab`, `zoomed`             | Chooses where Herdr opens review panes: over the active pane, beside it, in a new tab, or as a zoomed pane.                |
-| `review.exclude_untracked` | `true` / `false`                                | Hides untracked files from working-tree, staged, and branch reviews.                                                       |
+| Setting                    | Accepted values                                 | Effect                                                                                                                                  |
+| -------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `review.auto_open`         | `true` / `false`                                | Opens or refreshes a review when an associated agent enters a configured state.                                                         |
+| `review.on_states`         | List of `idle`, `working`, `blocked`, `unknown` | Selects the Herdr agent states that trigger automatic opening. An empty list disables all triggers.                                     |
+| `review.reuse_pane`        | `true` / `false`                                | Refreshes the worktree's existing review pane when possible instead of opening another pane.                                            |
+| `review.default_target`    | `auto`, `working`, `staged`, `branch`           | Chooses what the `review` action shows. `auto` shows uncommitted changes when the working tree is dirty, and the branch diff otherwise. |
+| `review.base`              | A branch name or ref, e.g. `origin/develop`     | Comparison base for branch reviews. Empty detects one, as described under [Base branch resolution](#base-branch-resolution).            |
+| `review.watch`             | `true` / `false`                                | Passes `--watch` to Hunk so an open review refreshes as its underlying source changes.                                                  |
+| `review.placement`         | `overlay`, `split`, `tab`, `zoomed`             | Chooses where Herdr opens review panes: over the active pane, beside it, in a new tab, or as a zoomed pane.                             |
+| `review.exclude_untracked` | `true` / `false`                                | Hides untracked files from working-tree, staged, and branch reviews.                                                                    |
 
 </details>
 
@@ -281,11 +302,19 @@ Automatic opens target the pane that emitted the agent event.
 
 ### Review target and display
 
-`default_target = "auto"` selects a branch review only when the current branch has commits ahead of
-its resolved base. Otherwise, it opens the working tree.
+`default_target = "auto"` resolves in the order Hunk itself uses:
 
-`exclude_untracked = true` hides untracked files in working-tree, staged, and branch reviews. Hunk
-does not accept that option for commit or stash reviews.
+1. The working tree, whenever it has uncommitted changes — the same thing bare `hunk diff` and
+   `git diff` show
+2. The branch diff `<base>...HEAD`, when the tree is clean and the branch is ahead of its base
+3. The working tree, when neither applies
+
+Pick a fixed target with `default_target = "working"` or `"branch"` if you would rather not have it
+depend on the state of the tree. The pane title always names what was resolved.
+
+`exclude_untracked = true` hides untracked files in working-tree, staged, and branch reviews, and
+also keeps untracked files from making `auto` treat the tree as dirty. Hunk does not accept that
+option for commit or stash reviews.
 
 `placement` supports the four persistent Herdr placements that return a pane ID. Herdr's modal
 `popup` placement is intentionally excluded because it cannot be reused, addressed, closed, or

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://github.com/user-attachments/assets/a36991a9-288f-4c8a-845c-ce2399334b9b
 - [Requirements](#requirements)
 - [Quick start](#quick-start)
 - [Keybinding behavior](#keybinding-behavior)
-- [Review actions](#review-actions) &middot; [Base branch resolution](#base-branch-resolution) &middot; [Which diff am I looking at?](#which-diff-am-i-looking-at) &middot; [GitHub commit links](#github-commit-links)
+- [Review actions](#review-actions) &middot; [Base branch resolution](#base-branch-resolution) &middot; [GitHub commit links](#github-commit-links)
 - [Configuration](#configuration) &middot; [Options](#option-reference) &middot; [Automatic opening](#automatic-opening) &middot; [Target and display](#review-target-and-display) &middot; [Round-trip prompts](#round-trip-prompts) &middot; [Hunk executable](#hunk-executable)
 - [Optional VCS pager setup](#optional-vcs-pager-setup)
 - [Direct hunk workflows](#direct-hunk-workflows)
@@ -99,8 +99,8 @@ herdr plugin action invoke send-review \
 3. Leave comments with hunk's normal inline-comment controls.
 4. Press `prefix+shift+s`, or invoke the CLI `send-review` action.
 
-By default, `review` shows the branch diff when the branch is ahead of its base. Otherwise, it
-shows the working tree. The plugin reads only your human-authored comments; agent annotations
+By default, `review` shows uncommitted changes. When the tree is clean and the branch is ahead
+of its base, it shows the branch diff. The plugin reads only your human-authored comments; agent annotations
 remain in the review for context.
 
 `send-review` formats all unsent comments into one prompt and submits it to the associated agent.
@@ -176,26 +176,15 @@ Branch reviews resolve their base in this order:
 3. `origin/HEAD`
 4. The first existing branch named `main`, `master`, or `trunk`
 
-Steps 2-4 keep a feature branch that deliberately tracks `origin/main` working as expected while
-avoiding an empty comparison against `origin/<same-feature-branch>`. They also mean a branch cut
-from something other than the repository's default branch resolves to that default rather than to
-the branch it was actually cut from, because Git does not record where a branch came from. Set
-`review.base` when you want a different base:
+Git does not record the branch a feature branch was created from. Set `review.base` to choose
+a different comparison base:
 
 ```toml
 [review]
 base = "origin/develop"
 ```
 
-A `review.base` that does not exist is reported, and the review falls back to detection rather
-than handing Hunk a range it cannot resolve. An explicit range passed to `review:branch` still
-wins over both.
-
-### Which diff am I looking at?
-
-The review pane's title names the resolved target — `Review: my-repo — origin/main...HEAD`,
-`Review: my-repo — working tree`, `Review: my-repo — staged`, `Review: my-repo — commit abc1234`
-— so `auto` never leaves the comparison a guess.
+If the configured ref cannot be resolved to a commit, the plugin warns and falls back to detection.
 
 ### GitHub commit links
 
@@ -248,16 +237,16 @@ extra_args   = []
 <details>
 <summary><b><code>[review]</code></b> — what opens, where, and when</summary>
 
-| Setting                    | Accepted values                                 | Effect                                                                                                                                  |
-| -------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `review.auto_open`         | `true` / `false`                                | Opens or refreshes a review when an associated agent enters a configured state.                                                         |
-| `review.on_states`         | List of `idle`, `working`, `blocked`, `unknown` | Selects the Herdr agent states that trigger automatic opening. An empty list disables all triggers.                                     |
-| `review.reuse_pane`        | `true` / `false`                                | Refreshes the worktree's existing review pane when possible instead of opening another pane.                                            |
-| `review.default_target`    | `auto`, `working`, `staged`, `branch`           | Chooses what the `review` action shows. `auto` shows uncommitted changes when the working tree is dirty, and the branch diff otherwise. |
-| `review.base`              | A branch name or ref, e.g. `origin/develop`     | Comparison base for branch reviews. Empty detects one, as described under [Base branch resolution](#base-branch-resolution).            |
-| `review.watch`             | `true` / `false`                                | Passes `--watch` to Hunk so an open review refreshes as its underlying source changes.                                                  |
-| `review.placement`         | `overlay`, `split`, `tab`, `zoomed`             | Chooses where Herdr opens review panes: over the active pane, beside it, in a new tab, or as a zoomed pane.                             |
-| `review.exclude_untracked` | `true` / `false`                                | Hides untracked files from working-tree, staged, and branch reviews.                                                                    |
+| Setting                    | Accepted values                                 | Effect                                                                                                                       |
+| -------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `review.auto_open`         | `true` / `false`                                | Opens or refreshes a review when an associated agent enters a configured state.                                              |
+| `review.on_states`         | List of `idle`, `working`, `blocked`, `unknown` | Selects the Herdr agent states that trigger automatic opening. An empty list disables all triggers.                          |
+| `review.reuse_pane`        | `true` / `false`                                | Refreshes the worktree's existing review pane when possible instead of opening another pane.                                 |
+| `review.default_target`    | `auto`, `working`, `staged`, `branch`           | Chooses the default review target. See [Review target and display](#review-target-and-display) for `auto` selection.         |
+| `review.base`              | A branch name or ref, e.g. `origin/develop`     | Comparison base for branch reviews. Empty detects one, as described under [Base branch resolution](#base-branch-resolution). |
+| `review.watch`             | `true` / `false`                                | Passes `--watch` to Hunk so an open review refreshes as its underlying source changes.                                       |
+| `review.placement`         | `overlay`, `split`, `tab`, `zoomed`             | Chooses where Herdr opens review panes: over the active pane, beside it, in a new tab, or as a zoomed pane.                  |
+| `review.exclude_untracked` | `true` / `false`                                | Hides untracked files from working-tree, staged, and branch reviews.                                                         |
 
 </details>
 
@@ -302,15 +291,15 @@ Automatic opens target the pane that emitted the agent event.
 
 ### Review target and display
 
-`default_target = "auto"` resolves in the order Hunk itself uses:
+`default_target = "auto"` selects:
 
-1. The working tree, whenever it has uncommitted changes — the same thing bare `hunk diff` and
-   `git diff` show
+1. The working tree when it has staged, unstaged, or untracked changes
 2. The branch diff `<base>...HEAD`, when the tree is clean and the branch is ahead of its base
 3. The working tree, when neither applies
 
-Pick a fixed target with `default_target = "working"` or `"branch"` if you would rather not have it
-depend on the state of the tree. The pane title always names what was resolved.
+Set `default_target` to `"working"`, `"staged"`, or `"branch"` for a fixed target.
+The pane title identifies the target, for example `Review: my-repo — origin/main...HEAD`
+or `Review: my-repo — staged`.
 
 `exclude_untracked = true` hides untracked files in working-tree, staged, and branch reviews, and
 also keeps untracked files from making `auto` treat the tree as dirty. Hunk does not accept that

--- a/src/bin/event.ts
+++ b/src/bin/event.ts
@@ -7,6 +7,7 @@ import { realRunner, realTargetDeps, repoRoot } from "../git.js";
 import { resolveTarget } from "../target.js";
 import { handleEvent, parseEvent, worktreeForPaneVia, type EventDeps } from "../events.js";
 import { isMainModule } from "./main-guard.js";
+import { reportReviewMetadata } from "../metadata.js";
 
 /** Builds dependencies for one short-lived manifest event-hook process. */
 export interface EventBinDeps {
@@ -19,15 +20,16 @@ const defaultDeps: EventBinDeps = {
     const cfg = loadConfig(env.HERDR_PLUGIN_CONFIG_DIR ?? ".");
     const launcher = resolveHunkLauncher(cfg, env.HERDR_PLUGIN_ROOT ?? process.cwd());
     const hunk = new HunkAdapter(launcher.bin, launcher.prefix);
+    const index = new ReviewIndex(env.HERDR_PLUGIN_STATE_DIR ?? ".");
     return {
       cfg,
-      index: new ReviewIndex(env.HERDR_PLUGIN_STATE_DIR ?? "."),
+      index,
       herdr,
       worktreeForPane: worktreeForPaneVia(herdr, (dir) => repoRoot(dir, realRunner(dir))),
-      reloadReview: (worktree) => {
-        const target = resolveTarget({ cwd: worktree }, cfg, realTargetDeps(realRunner));
-        return hunk.reload(worktree, target, cfg);
-      },
+      resolveTarget: (worktree) =>
+        resolveTarget({ cwd: worktree }, cfg, realTargetDeps(realRunner)),
+      reloadReview: (target) => hunk.reload(target.worktree, target, cfg),
+      reportReviewMetadata: (worktree) => reportReviewMetadata({ index, herdr, hunk }, worktree),
     };
   },
 };

--- a/src/bin/event.ts
+++ b/src/bin/event.ts
@@ -3,7 +3,7 @@ import { loadConfig } from "../config.js";
 import { HerdrAdapter, resolveHunkLauncher } from "../herdr.js";
 import { HunkAdapter } from "../hunk.js";
 import { ReviewIndex } from "../index-store.js";
-import { hasCommitsAhead, realRunner, repoRoot, resolveBaseRef } from "../git.js";
+import { realRunner, realTargetDeps, repoRoot } from "../git.js";
 import { resolveTarget } from "../target.js";
 import { handleEvent, parseEvent, worktreeForPaneVia, type EventDeps } from "../events.js";
 import { isMainModule } from "./main-guard.js";
@@ -25,11 +25,7 @@ const defaultDeps: EventBinDeps = {
       herdr,
       worktreeForPane: worktreeForPaneVia(herdr, (dir) => repoRoot(dir, realRunner(dir))),
       reloadReview: (worktree) => {
-        const target = resolveTarget({ cwd: worktree }, cfg, {
-          resolveBaseRef: (repo) => resolveBaseRef(repo, realRunner(repo)),
-          hasCommitsAhead: (repo, base) => hasCommitsAhead(repo, base, realRunner(repo)),
-          repoRoot: (dir) => repoRoot(dir, realRunner(dir)),
-        });
+        const target = resolveTarget({ cwd: worktree }, cfg, realTargetDeps(realRunner));
         return hunk.reload(worktree, target, cfg);
       },
     };

--- a/src/bin/pane.ts
+++ b/src/bin/pane.ts
@@ -7,7 +7,7 @@ import { readContext } from "../context.js";
 import { HerdrAdapter, resolveHunkLauncher } from "../herdr.js";
 import { buildLaunchArgs } from "../hunk.js";
 import { ReviewIndex } from "../index-store.js";
-import { hasCommitsAhead, realRunner, repoRoot, resolveBaseRef } from "../git.js";
+import { realRunner, realTargetDeps } from "../git.js";
 import { sidecarPath } from "../notes.js";
 import { resolveTarget, type Target } from "../target.js";
 import { isMainModule } from "./main-guard.js";
@@ -34,11 +34,7 @@ export function resolveAndRun(
     actionId && isReviewAction(actionId) ? reviewRequestFor(actionId) : { takesRef: false };
 
   const stateDir = env.HERDR_PLUGIN_STATE_DIR ?? ".";
-  const targetDeps = {
-    resolveBaseRef: (repo: string) => resolveBaseRef(repo, realRunner(repo)),
-    hasCommitsAhead: (repo: string, base: string) => hasCommitsAhead(repo, base, realRunner(repo)),
-    repoRoot: (dir: string) => repoRoot(dir, realRunner(dir)),
-  };
+  const targetDeps = realTargetDeps(realRunner);
   let target: Target = resolveTarget({ ...ctx, cwd }, cfg, targetDeps, request.mode);
 
   // Only ref-taking actions consume the value passed through the cross-process index.

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,8 @@ export interface PluginConfig {
     on_states: AgentState[];
     reuse_pane: boolean;
     default_target: DefaultTargetMode;
+    /** Comparison base for branch reviews; empty means detect one. */
+    base: string;
     watch: boolean;
     /** Passed to `hunk diff` as `--exclude-untracked`. */
     exclude_untracked: boolean;
@@ -56,6 +58,7 @@ export const DEFAULTS: PluginConfig = {
     on_states: ["idle"],
     reuse_pane: true,
     default_target: "auto",
+    base: "",
     watch: false,
     exclude_untracked: false,
     placement: "split",
@@ -115,6 +118,7 @@ export function loadConfig(configDir: string): PluginConfig {
       on_states: subset(r.on_states, AGENT_STATES, DEFAULTS.review.on_states),
       reuse_pane: bool(r.reuse_pane, DEFAULTS.review.reuse_pane),
       default_target: pick(r.default_target, TARGET, DEFAULTS.review.default_target),
+      base: typeof r.base === "string" ? r.base : DEFAULTS.review.base,
       watch: bool(r.watch, DEFAULTS.review.watch),
       exclude_untracked: bool(r.exclude_untracked, DEFAULTS.review.exclude_untracked),
       placement: pick(r.placement, PLACEMENTS, DEFAULTS.review.placement),

--- a/src/events.ts
+++ b/src/events.ts
@@ -3,6 +3,7 @@ import type { Placement, PluginConfig } from "./config.js";
 import { reportFailure } from "./herdr.js";
 import type { ReviewIndex } from "./index-store.js";
 import { asObject, asString, parseJsonObject, type JsonObject } from "./json.js";
+import { describeTarget, type Target } from "./target.js";
 
 /**
  * Global manifest hooks. Socket subscriptions require a pane id for agent status events and cannot
@@ -29,8 +30,9 @@ export interface EventDeps {
     closePane: (paneId: string) => void;
   };
   worktreeForPane: (paneId: string) => string | null;
-  /** Re-points an existing review to the worktree's current default target. */
-  reloadReview: (worktree: string) => Promise<void>;
+  resolveTarget: (worktree: string) => Target;
+  reloadReview: (target: Target) => Promise<void>;
+  reportReviewMetadata: (worktree: string) => Promise<void>;
 }
 
 export interface HerdrEvent {
@@ -119,15 +121,23 @@ async function agentStatusChanged(data: JsonObject, deps: EventDeps): Promise<nu
 
   if (!deps.cfg.review.auto_open) return 0;
 
+  const target = deps.resolveTarget(worktree);
+  if (target.warning) deps.herdr.notify(target.warning);
+  const display = {
+    requestedMode: target.mode,
+    requestedRef: null,
+    displayedTarget: describeTarget(target),
+  };
   const existing = deps.index.get(worktree);
   if (deps.cfg.review.reuse_pane && existing?.paneId) {
     try {
-      await deps.reloadReview(worktree);
+      await deps.reloadReview(target);
       deps.index.upsert({
         worktree,
-        requestedMode: null,
+        ...display,
         sent: deps.index.sentIds(worktree),
       });
+      await deps.reportReviewMetadata(worktree);
       return 0;
     } catch {
       // A stale pane id must not prevent a fresh auto-open; preserve delivery history.
@@ -136,17 +146,16 @@ async function agentStatusChanged(data: JsonObject, deps: EventDeps): Promise<nu
   }
 
   const entrypoint = paneEntrypointFor("review");
+  deps.index.upsert({ worktree, ...display, sent: [] });
   const pane = deps.herdr.openPane({
     entrypoint,
     cwd: worktree,
     placement: deps.cfg.review.placement,
     targetPane: paneId,
   });
-  // Plain review entrypoints use the config default, so clear any previously explicit mode.
   deps.index.upsert({
     worktree,
     paneId: pane ?? undefined,
-    requestedMode: null,
     sent: deps.index.sentIds(worktree),
   });
   if (!pane) {
@@ -157,6 +166,7 @@ async function agentStatusChanged(data: JsonObject, deps: EventDeps): Promise<nu
         "`herdr plugin log list` has the open that failed.",
     );
   }
+  await deps.reportReviewMetadata(worktree);
   return 0;
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -70,16 +70,12 @@ export function commitExists(repo: string, ref: string, run: Runner): boolean {
 
 /** Reports uncommitted work; omitting untracked files mirrors an `--exclude-untracked` review. */
 export function hasWorkingChanges(repo: string, includeUntracked: boolean, run: Runner): boolean {
-  const args = ["status", "--porcelain"];
-  if (!includeUntracked) args.push("--untracked-files=no");
+  const args = ["status", "--porcelain", `--untracked-files=${includeUntracked ? "normal" : "no"}`];
   const r = run("git", args);
   return r.status === 0 && r.stdout.trim().length > 0;
 }
 
-/**
- * One wiring of target resolution over git, shared by every entry point. The runner factory is a
- * parameter so callers keep it observable; resolving it here would hide every git call from tests.
- */
+/** Git dependencies shared by the action, pane, and event entrypoints. */
 export function realTargetDeps(runnerFor: (dir: string) => Runner): TargetDeps {
   return {
     resolveBaseRef: (repo) => resolveBaseRef(repo, runnerFor(repo)),

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import type { TargetDeps } from "./target.js";
 
 export type Runner = (cmd: string, args: string[]) => { status: number; stdout: string };
 
@@ -65,4 +66,27 @@ export function hasCommitsAhead(repo: string, base: string, run: Runner): boolea
 /** `^{commit}` so an existing blob or tree name does not pass as a reviewable commit. */
 export function commitExists(repo: string, ref: string, run: Runner): boolean {
   return run("git", ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`]).status === 0;
+}
+
+/** Reports uncommitted work; omitting untracked files mirrors an `--exclude-untracked` review. */
+export function hasWorkingChanges(repo: string, includeUntracked: boolean, run: Runner): boolean {
+  const args = ["status", "--porcelain"];
+  if (!includeUntracked) args.push("--untracked-files=no");
+  const r = run("git", args);
+  return r.status === 0 && r.stdout.trim().length > 0;
+}
+
+/**
+ * One wiring of target resolution over git, shared by every entry point. The runner factory is a
+ * parameter so callers keep it observable; resolving it here would hide every git call from tests.
+ */
+export function realTargetDeps(runnerFor: (dir: string) => Runner): TargetDeps {
+  return {
+    resolveBaseRef: (repo) => resolveBaseRef(repo, runnerFor(repo)),
+    hasCommitsAhead: (repo, base) => hasCommitsAhead(repo, base, runnerFor(repo)),
+    repoRoot: (dir) => repoRoot(dir, runnerFor(dir)),
+    hasWorkingChanges: (repo, includeUntracked) =>
+      hasWorkingChanges(repo, includeUntracked, runnerFor(repo)),
+    commitExists: (repo, ref) => commitExists(repo, ref, runnerFor(repo)),
+  };
 }

--- a/src/index-store.ts
+++ b/src/index-store.ts
@@ -30,6 +30,8 @@ export interface ReviewEntry {
   requestedRef?: string | null;
   /** Mode currently displayed, used by reload; `null` restores config-driven selection. */
   requestedMode?: ResolvedTargetMode | null;
+  /** Label of the target last opened or reloaded in the pane. */
+  displayedTarget?: string | null;
   sent: string[];
 }
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,0 +1,30 @@
+import { basename } from "node:path";
+import { selectUnsent } from "./courier.js";
+import type { HerdrAdapter } from "./herdr.js";
+import type { HunkAdapter } from "./hunk.js";
+import type { ReviewIndex } from "./index-store.js";
+
+interface MetadataDeps {
+  index: ReviewIndex;
+  herdr: Partial<Pick<HerdrAdapter, "reportMetadata">>;
+  hunk: Pick<HunkAdapter, "listComments">;
+}
+
+// Metadata is cosmetic and only applies while a review pane is open.
+export async function reportReviewMetadata(rt: MetadataDeps, worktree: string): Promise<void> {
+  if (!rt.herdr.reportMetadata) return;
+  const entry = rt.index.get(worktree);
+  if (!entry?.paneId) return;
+  const unsentCount = selectUnsent(
+    await rt.hunk.listComments(worktree, "user").catch(() => []),
+    rt.index.sentIds(worktree),
+  ).length;
+  try {
+    rt.herdr.reportMetadata(entry.paneId, {
+      title: `Review: ${basename(worktree)}${entry.displayedTarget ? ` — ${entry.displayedTarget}` : ""}`,
+      display_agent: unsentCount > 0 ? `hunk (${unsentCount} unsent)` : "hunk",
+    });
+  } catch {
+    // Metadata failures must not fail a completed action.
+  }
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8,8 +8,8 @@ import { ReviewIndex, type ReviewEntry } from "./index-store.js";
 import { formatReview, selectUnsent } from "./courier.js";
 import { parseGithubUrl } from "./notes.js";
 import { installPager, realPagerEffects, uninstallPager } from "./pager.js";
-import { resolveTarget, type Target } from "./target.js";
-import { commitExists, hasCommitsAhead, realRunner, repoRoot, resolveBaseRef } from "./git.js";
+import { describeTarget, resolveTarget, type Target } from "./target.js";
+import { commitExists, realRunner, realTargetDeps } from "./git.js";
 import {
   isReviewAction,
   paneEntrypointFor,
@@ -41,11 +41,7 @@ export function buildRuntime(env: NodeJS.ProcessEnv): Runtime {
   const pluginRoot = env.HERDR_PLUGIN_ROOT ?? process.cwd();
 
   // Avoid Git subprocesses for actions that never inspect a review target.
-  const targetDeps = {
-    resolveBaseRef: (repo: string) => resolveBaseRef(repo, realRunner(repo)),
-    hasCommitsAhead: (repo: string, base: string) => hasCommitsAhead(repo, base, realRunner(repo)),
-    repoRoot: (dir: string) => repoRoot(dir, realRunner(dir)),
-  };
+  const targetDeps = realTargetDeps(realRunner);
 
   let resolvedTarget: Target | undefined;
   const targetFor = (mode?: TargetMode, ref?: string): Target => {
@@ -85,7 +81,7 @@ async function reportReviewMetadata(rt: Runtime, target: Target): Promise<void> 
   ).length;
   try {
     rt.herdr.reportMetadata(entry.paneId, {
-      title: `Review: ${basename(target.worktree)}`,
+      title: `Review: ${basename(target.worktree)} — ${describeTarget(target)}`,
       display_agent: unsentCount > 0 ? `hunk (${unsentCount} unsent)` : "hunk",
     });
   } catch {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,5 +1,4 @@
 import { spawnSync } from "node:child_process";
-import { basename } from "node:path";
 import { loadConfig, type PluginConfig, type TargetMode } from "./config.js";
 import { readContext, type HerdrContext } from "./context.js";
 import { HerdrAdapter, reportFailure, resolveHunkLauncher } from "./herdr.js";
@@ -16,6 +15,7 @@ import {
   reviewRequestFor,
   type ReviewActionId,
 } from "./actions.js";
+import { reportReviewMetadata } from "./metadata.js";
 import { DEFAULT_BINDINGS } from "./keys.js";
 import { installKeys, removeKeys, resolveHerdrConfigPath } from "./keys-install.js";
 
@@ -70,25 +70,6 @@ export function buildRuntime(env: NodeJS.ProcessEnv): Runtime {
   };
 }
 
-// Metadata is cosmetic and only applies while a review pane is open.
-async function reportReviewMetadata(rt: Runtime, target: Target): Promise<void> {
-  if (!("reportMetadata" in rt.herdr)) return;
-  const entry = rt.index.get(target.worktree);
-  if (!entry?.paneId) return;
-  const unsentCount = selectUnsent(
-    await rt.hunk.listComments(target.worktree, "user").catch(() => []),
-    rt.index.sentIds(target.worktree),
-  ).length;
-  try {
-    rt.herdr.reportMetadata(entry.paneId, {
-      title: `Review: ${basename(target.worktree)} — ${describeTarget(target)}`,
-      display_agent: unsentCount > 0 ? `hunk (${unsentCount} unsent)` : "hunk",
-    });
-  } catch {
-    // Metadata failures must not fail a completed action.
-  }
-}
-
 /**
  * Records what the pane displays for the separate pane process and later reloads. Store only the
  * caller-supplied ref; derived branch ranges must be resolved again.
@@ -96,10 +77,11 @@ async function reportReviewMetadata(rt: Runtime, target: Target): Promise<void> 
 function displayedReviewRecord(
   target: Target,
   suppliedRef: string | undefined,
-): Pick<ReviewEntry, "requestedMode" | "requestedRef"> {
+): Pick<ReviewEntry, "requestedMode" | "requestedRef" | "displayedTarget"> {
   return {
     requestedRef: suppliedRef ?? null,
     requestedMode: target.mode,
+    displayedTarget: describeTarget(target),
   };
 }
 
@@ -130,7 +112,7 @@ async function reviewAction(actionId: ReviewActionId, rt: Runtime): Promise<numb
         ...displayedReviewRecord(target, suppliedRef),
         sent: [],
       });
-      await reportReviewMetadata(rt, target);
+      await reportReviewMetadata(rt, target.worktree);
       return 0;
     } catch (err) {
       // The pane may be stale; preserve sent history and fall through to a fresh open.
@@ -168,7 +150,7 @@ async function reviewAction(actionId: ReviewActionId, rt: Runtime): Promise<numb
   }
   // The pane id is only available after launch; undefined fields preserve the pre-launch record.
   rt.index.upsert({ worktree: target.worktree, paneId, sent: [] });
-  await reportReviewMetadata(rt, target);
+  await reportReviewMetadata(rt, target.worktree);
   return 0;
 }
 
@@ -240,7 +222,7 @@ async function sendReview(rt: Runtime): Promise<number> {
     }
   }
   rt.herdr.notify(`Sent ${unsent.length} comment(s) to ${label ?? target}.`);
-  await reportReviewMetadata(rt, rt.target);
+  await reportReviewMetadata(rt, worktree);
   return 0;
 }
 
@@ -288,6 +270,13 @@ export async function dispatch(actionId: string, rt: Runtime): Promise<number> {
       } catch (err) {
         return reportFailure(rt.herdr, `Could not reload the review. ${hunkErrorMessage(err)}`);
       }
+      rt.index.upsert({
+        worktree: target.worktree,
+        ...displayedReviewRecord(target, recorded?.requestedRef ?? undefined),
+        sent: [],
+      });
+      if (target.warning) rt.herdr.notify(target.warning);
+      await reportReviewMetadata(rt, target.worktree);
       return 0;
     }
     case "close-review": {

--- a/src/target.ts
+++ b/src/target.ts
@@ -14,6 +14,26 @@ export interface TargetDeps {
   hasCommitsAhead: (repo: string, base: string) => boolean;
   /** Resolves repository identity from an arbitrary directory. */
   repoRoot: (dir: string) => string | null;
+  /** Reports uncommitted work, so auto can match `hunk diff` and show it first. */
+  hasWorkingChanges: (repo: string, includeUntracked: boolean) => boolean;
+  /** Validates a configured base before it reaches hunk as a range. */
+  commitExists: (repo: string, ref: string) => boolean;
+}
+
+/** Names what a resolved target displays, for panes and warnings. */
+export function describeTarget(target: Omit<Target, "warning">): string {
+  switch (target.mode) {
+    case "staged":
+      return "staged";
+    case "branch":
+      return target.ref ?? "branch";
+    case "commit":
+      return target.ref ? `commit ${target.ref}` : "last commit";
+    case "stash":
+      return target.ref ?? "latest stash";
+    default:
+      return "working tree";
+  }
 }
 
 /** Resolves config defaults plus optional action mode and ref overrides. */
@@ -45,9 +65,22 @@ export function resolveTarget(
   const withWarning = (target: Omit<Target, "warning">): Target =>
     warnings.length > 0 ? { ...target, warning: warnings.join(" ") } : target;
 
+  // A configured base beats detection, but only once git confirms it; a typo would reach hunk.
+  const baseRef = (): string | null => {
+    const configured = cfg.review.base.trim();
+    if (!configured) return deps.resolveBaseRef(worktree);
+    if (deps.commitExists(worktree, configured)) return configured;
+    const detected = deps.resolveBaseRef(worktree);
+    warnings.push(
+      `Configured base "${configured}" does not exist in this repository; ` +
+        (detected ? `comparing against ${detected} instead.` : "no base branch resolved."),
+    );
+    return detected;
+  };
+
   // A branch target without a base would silently become a working-tree diff.
   const branchTarget = (): Omit<Target, "warning"> | null => {
-    const base = deps.resolveBaseRef(worktree);
+    const base = baseRef();
     if (!base) {
       warnings.push("No base branch resolved; reviewing the working tree instead.");
       return null;
@@ -66,7 +99,12 @@ export function resolveTarget(
 
   if (requested !== "auto") return withWarning({ worktree, mode: requested });
 
-  const base = deps.resolveBaseRef(worktree);
+  // Uncommitted work wins, matching what bare `hunk diff` and `git diff` show.
+  if (deps.hasWorkingChanges(worktree, !cfg.review.exclude_untracked)) {
+    return withWarning({ worktree, mode: "working" });
+  }
+
+  const base = baseRef();
   if (!base) {
     warnings.push("No base branch resolved; reviewing the working tree instead.");
     return withWarning({ worktree, mode: "working" });

--- a/src/target.ts
+++ b/src/target.ts
@@ -14,7 +14,7 @@ export interface TargetDeps {
   hasCommitsAhead: (repo: string, base: string) => boolean;
   /** Resolves repository identity from an arbitrary directory. */
   repoRoot: (dir: string) => string | null;
-  /** Reports uncommitted work, so auto can match `hunk diff` and show it first. */
+  /** Reports tracked changes and, optionally, untracked files. */
   hasWorkingChanges: (repo: string, includeUntracked: boolean) => boolean;
   /** Validates a configured base before it reaches hunk as a range. */
   commitExists: (repo: string, ref: string) => boolean;
@@ -65,7 +65,7 @@ export function resolveTarget(
   const withWarning = (target: Omit<Target, "warning">): Target =>
     warnings.length > 0 ? { ...target, warning: warnings.join(" ") } : target;
 
-  // A configured base beats detection, but only once git confirms it; a typo would reach hunk.
+  // Validate the configured base before constructing a revision range.
   const baseRef = (): string | null => {
     const configured = cfg.review.base.trim();
     if (!configured) return deps.resolveBaseRef(worktree);
@@ -99,7 +99,7 @@ export function resolveTarget(
 
   if (requested !== "auto") return withWarning({ worktree, mode: requested });
 
-  // Uncommitted work wins, matching what bare `hunk diff` and `git diff` show.
+  // Prefer uncommitted changes over the branch diff.
   if (deps.hasWorkingChanges(worktree, !cfg.review.exclude_untracked)) {
     return withWarning({ worktree, mode: "working" });
   }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -31,6 +31,7 @@ describe("loadConfig", () => {
   it("exposes no config keys the plugin does not act on", () => {
     expect(Object.keys(DEFAULTS.review).sort()).toEqual([
       "auto_open",
+      "base",
       "default_target",
       "exclude_untracked",
       "on_states",
@@ -183,5 +184,25 @@ describe("loadConfig", () => {
     it("honours an explicitly empty extra_args", () => {
       expect(loadConfig(withConfig(`[hunk]\nextra_args = []\n`)).hunk.extra_args).toEqual([]);
     });
+  });
+});
+
+describe("the configured review base", () => {
+  it("reads a base branch from the file", () => {
+    expect(loadConfig(withConfig(`[review]\nbase = "develop"\n`)).review.base).toBe("develop");
+  });
+
+  it("reads a remote-qualified base", () => {
+    expect(loadConfig(withConfig(`[review]\nbase = "origin/develop"\n`)).review.base).toBe(
+      "origin/develop",
+    );
+  });
+
+  it("defaults to empty, leaving detection in charge", () => {
+    expect(DEFAULTS.review.base).toBe("");
+  });
+
+  it("rejects a non-string base rather than reaching git with it", () => {
+    expect(loadConfig(withConfig(`[review]\nbase = 7\n`)).review.base).toBe("");
   });
 });

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -49,6 +49,8 @@ function deps(over: Record<string, any> = {}) {
       closePane: vi.fn(),
     },
     worktreeForPane: vi.fn(() => "/wt/x"),
+    resolveTarget: vi.fn(() => ({ worktree: "/wt/x", mode: "working" })),
+    reportReviewMetadata: vi.fn(async () => {}),
     ...over,
   };
 }
@@ -136,7 +138,7 @@ describe("handleEvent: an agent reaching a reviewable state", () => {
     const d = deps({ cfg: { ...DEFAULTS, review: { ...DEFAULTS.review, auto_open: true } } });
     d.index.upsert({ worktree: "/wt/x", requestedMode: "staged", sent: [] });
     await fire(finishedEvent, d);
-    expect(d.index.get("/wt/x")?.requestedMode).toBeUndefined();
+    expect(d.index.get("/wt/x")?.requestedMode).toBe("working");
     expect(d.index.get("/wt/x")?.paneId).toBe("w1:p7");
   });
 
@@ -151,7 +153,7 @@ describe("handleEvent: an agent reaching a reviewable state", () => {
       const d = autoOpenDeps();
       d.index.upsert({ worktree: "/wt/x", paneId: "w1:p7", sent: [] });
       await fire(finishedEvent, d);
-      expect(d.reloadReview).toHaveBeenCalledWith("/wt/x");
+      expect(d.reloadReview).toHaveBeenCalledWith({ worktree: "/wt/x", mode: "working" });
       expect(d.herdr.openPane).not.toHaveBeenCalled();
       expect(d.index.get("/wt/x")?.paneId).toBe("w1:p7");
     });
@@ -200,8 +202,31 @@ describe("handleEvent: an agent reaching a reviewable state", () => {
       const d = autoOpenDeps();
       d.index.upsert({ worktree: "/wt/x", paneId: "w1:p7", requestedMode: "staged", sent: [] });
       await fire(finishedEvent, d);
-      expect(d.index.get("/wt/x")?.requestedMode).toBeUndefined();
+      expect(d.index.get("/wt/x")?.requestedMode).toBe("working");
     });
+  });
+
+  it.each([false, true])("updates metadata on auto-open (reuse=%s)", async (reuse) => {
+    const d = deps({
+      cfg: { ...DEFAULTS, review: { ...DEFAULTS.review, auto_open: true } },
+      reloadReview: vi.fn(async () => {}),
+    });
+    if (reuse)
+      d.index.upsert({
+        worktree: "/wt/x",
+        paneId: "w1:p7",
+        sent: [],
+        requestedMode: "commit",
+        requestedRef: "abc1234",
+        displayedTarget: "commit abc1234",
+      });
+    await fire(finishedEvent, d);
+    expect(d.reportReviewMetadata).toHaveBeenCalledWith("/wt/x");
+    expect(d.index.get("/wt/x")).toMatchObject({
+      requestedMode: "working",
+      displayedTarget: "working tree",
+    });
+    expect(d.index.get("/wt/x")?.requestedRef).toBeUndefined();
   });
 
   it("does nothing when auto_open is disabled", async () => {

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -8,9 +8,13 @@ import {
   hasCommitsAhead,
   hasWorkingChanges,
   realRunner,
+  realTargetDeps,
   resolveBaseRef,
   type Runner,
 } from "../src/git.js";
+
+import { DEFAULTS } from "../src/config.js";
+import { resolveTarget } from "../src/target.js";
 
 function runner(table: Record<string, { status?: number; stdout?: string }>): Runner {
   return (_cmd, args) => {
@@ -232,6 +236,21 @@ describe("resolveBaseRef against real git", { timeout: 15_000 }, () => {
     git(repo, "commit", "-qam", `work on ${branch}`);
   }
 
+  it("auto detects untracked files even when Git status hides them", () => {
+    const repo = repoWithOrigin();
+    commitOn(repo, "feature", "feature\n");
+    git(repo, "config", "status.showUntrackedFiles", "no");
+    writeFileSync(join(repo, "new.txt"), "new\n");
+    const deps = realTargetDeps(realRunner);
+    expect(resolveTarget({ worktree: repo }, DEFAULTS, deps).mode).toBe("working");
+    const cfg = { ...DEFAULTS, review: { ...DEFAULTS.review, exclude_untracked: true } };
+    expect(resolveTarget({ worktree: repo }, cfg, deps).mode).toBe("branch");
+    writeFileSync(join(repo, "a.txt"), "modified\n");
+    expect(resolveTarget({ worktree: repo }, cfg, deps).mode).toBe("working");
+    git(repo, "add", "a.txt");
+    expect(resolveTarget({ worktree: repo }, cfg, deps).mode).toBe("working");
+  });
+
   it("uses origin/HEAD for a feature branch with no upstream", () => {
     const repo = repoWithOrigin();
     commitOn(repo, "feat/no-upstream", "base\nfeature\n");
@@ -325,24 +344,30 @@ describe("commitExists", () => {
 
 describe("hasWorkingChanges", () => {
   it("reports modified tracked files", () => {
-    const run = runner({ "status --porcelain": { status: 0, stdout: " M src/a.ts\n" } });
+    const run = runner({
+      "status --porcelain --untracked-files=normal": { status: 0, stdout: " M src/a.ts\n" },
+    });
     expect(hasWorkingChanges("/repo", true, run)).toBe(true);
   });
 
   it("reports a clean tree as unchanged", () => {
-    const run = runner({ "status --porcelain": { status: 0, stdout: "\n" } });
+    const run = runner({
+      "status --porcelain --untracked-files=normal": { status: 0, stdout: "\n" },
+    });
     expect(hasWorkingChanges("/repo", true, run)).toBe(false);
   });
 
   it("counts untracked files when they are included", () => {
-    const run = runner({ "status --porcelain": { status: 0, stdout: "?? new.ts\n" } });
+    const run = runner({
+      "status --porcelain --untracked-files=normal": { status: 0, stdout: "?? new.ts\n" },
+    });
     expect(hasWorkingChanges("/repo", true, run)).toBe(true);
   });
 
   it("asks git to omit untracked files when they are excluded", () => {
     const run = runner({
       "status --porcelain --untracked-files=no": { status: 0, stdout: "" },
-      "status --porcelain": { status: 0, stdout: "?? new.ts\n" },
+      "status --porcelain --untracked-files=normal": { status: 0, stdout: "?? new.ts\n" },
     });
     expect(hasWorkingChanges("/repo", false, run)).toBe(false);
   });

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   commitExists,
   hasCommitsAhead,
+  hasWorkingChanges,
   realRunner,
   resolveBaseRef,
   type Runner,
@@ -319,5 +320,34 @@ describe("commitExists", () => {
 
   it("is false when git cannot resolve the name", () => {
     expect(commitExists("/repo", "nope", () => ({ status: 1, stdout: "" }))).toBe(false);
+  });
+});
+
+describe("hasWorkingChanges", () => {
+  it("reports modified tracked files", () => {
+    const run = runner({ "status --porcelain": { status: 0, stdout: " M src/a.ts\n" } });
+    expect(hasWorkingChanges("/repo", true, run)).toBe(true);
+  });
+
+  it("reports a clean tree as unchanged", () => {
+    const run = runner({ "status --porcelain": { status: 0, stdout: "\n" } });
+    expect(hasWorkingChanges("/repo", true, run)).toBe(false);
+  });
+
+  it("counts untracked files when they are included", () => {
+    const run = runner({ "status --porcelain": { status: 0, stdout: "?? new.ts\n" } });
+    expect(hasWorkingChanges("/repo", true, run)).toBe(true);
+  });
+
+  it("asks git to omit untracked files when they are excluded", () => {
+    const run = runner({
+      "status --porcelain --untracked-files=no": { status: 0, stdout: "" },
+      "status --porcelain": { status: 0, stdout: "?? new.ts\n" },
+    });
+    expect(hasWorkingChanges("/repo", false, run)).toBe(false);
+  });
+
+  it("reports no changes when git fails, leaving base detection to decide", () => {
+    expect(hasWorkingChanges("/repo", true, runner({}))).toBe(false);
   });
 });

--- a/tests/pane-index-invariant.test.ts
+++ b/tests/pane-index-invariant.test.ts
@@ -295,6 +295,8 @@ describe("the event hook's auto-open", () => {
         }),
       },
       worktreeForPane: () => WT,
+      resolveTarget: () => resolve(cfg),
+      reportReviewMetadata: vi.fn(async () => {}),
     };
     const payload = {
       event: "pane_agent_status_changed",
@@ -327,18 +329,18 @@ describe("the event hook's auto-open", () => {
     },
   );
 
-  it("corrects the stale mode only after openPane has spawned the pane", async () => {
+  it("records the resolved mode before openPane spawns the pane", async () => {
     const seed = harness(DEFAULTS, { worktree: WT, agentName: "reviewer" });
     expect(await dispatch("review:staged", seed.rt as any)).toBe(0);
 
     const d = hook(DEFAULTS, { dir: seed.dir, index: seed.index });
     await d.fire();
 
-    expect(entryAt(d.spawns[0].index, WT)?.requestedMode).toBe("staged");
-    expect(seed.index.get(WT)?.requestedMode).toBeUndefined();
+    expect(entryAt(d.spawns[0].index, WT)?.requestedMode).toBe("branch");
+    expect(seed.index.get(WT)?.requestedMode).toBe("branch");
   });
 
-  it("keeps a stale commit-ish for a pane that is not showing a commit", async () => {
+  it("clears a stale commit ref when auto-opening the default review", async () => {
     const shared = await paneShowingCommit(DEFAULTS);
     expect(shared.index.get(WT)?.requestedRef).toBe(SHA);
 
@@ -346,8 +348,8 @@ describe("the event hook's auto-open", () => {
     await d.fire();
 
     const record = shared.index.get(WT);
-    expect(record?.requestedMode).toBeUndefined();
-    expect(record?.requestedRef).toBe(SHA);
+    expect(record?.requestedMode).toBe("branch");
+    expect(record?.requestedRef).toBeUndefined();
     expect(
       resolve(DEFAULTS, record?.requestedMode ?? undefined, record?.requestedRef ?? undefined),
     ).toEqual(paneDisplays(DEFAULTS, d.spawns[0]));

--- a/tests/pane-index-invariant.test.ts
+++ b/tests/pane-index-invariant.test.ts
@@ -24,6 +24,8 @@ const GIT = {
   resolveBaseRef: () => "main",
   hasCommitsAhead: () => true,
   repoRoot: (dir: string) => dir,
+  hasWorkingChanges: () => false,
+  commitExists: () => true,
 };
 const resolve = (cfg: PluginConfig, mode?: TargetMode, ref?: string): Target =>
   resolveTarget({ worktree: WT }, cfg, GIT, mode, ref);

--- a/tests/runtime-actions.test.ts
+++ b/tests/runtime-actions.test.ts
@@ -258,7 +258,7 @@ describe("pane metadata reporting", () => {
     });
   });
 
-  it("also reports metadata after send-review completes", async () => {
+  it("preserves the displayed target when sending comments after config changes", async () => {
     const reportMetadata = vi.fn();
     const rt = runtime({
       herdr: {
@@ -277,12 +277,52 @@ describe("pane metadata reporting", () => {
         navigate: vi.fn(async () => {}),
       },
     });
-    rt.index.upsert({ worktree: "/wt/x", paneId: "w1:p7", sent: [] });
+    rt.index.upsert({
+      worktree: "/wt/x",
+      paneId: "w1:p7",
+      displayedTarget: "commit abc1234",
+      sent: [],
+    });
     expect(await dispatch("send-review", rt as any)).toBe(0);
     expect(reportMetadata).toHaveBeenCalledWith("w1:p7", {
-      title: "Review: x — working tree",
+      title: "Review: x — commit abc1234",
       display_agent: "hunk",
     });
+  });
+
+  it("updates the title after reloading against a changed base", async () => {
+    const rt = runtime();
+    rt.herdr.reportMetadata = vi.fn();
+    rt.index.upsert({
+      worktree: "/wt/x",
+      paneId: "w1:p7",
+      requestedMode: "branch",
+      displayedTarget: "main...HEAD",
+      sent: [],
+    });
+    rt.targetFor = () => ({ worktree: "/wt/x", mode: "branch", ref: "develop...HEAD" });
+    expect(await dispatch("reload", rt as any)).toBe(0);
+    expect(rt.herdr.reportMetadata).toHaveBeenCalledWith("w1:p7", {
+      title: "Review: x — develop...HEAD",
+      display_agent: "hunk",
+    });
+  });
+
+  it("keeps the displayed target after a failed reload", async () => {
+    const rt = runtime();
+    rt.herdr.reportMetadata = vi.fn();
+    rt.index.upsert({
+      worktree: "/wt/x",
+      paneId: "w1:p7",
+      requestedMode: "branch",
+      displayedTarget: "main...HEAD",
+      sent: [],
+    });
+    rt.targetFor = () => ({ worktree: "/wt/x", mode: "branch", ref: "develop...HEAD" });
+    rt.hunk.reload.mockRejectedValue(new Error("reload failed"));
+    expect(await dispatch("reload", rt as any)).toBe(1);
+    expect(rt.index.get("/wt/x")?.displayedTarget).toBe("main...HEAD");
+    expect(rt.herdr.reportMetadata).not.toHaveBeenCalled();
   });
 
   it("silently skips reporting when the herdr adapter has no reportMetadata (older CLI)", async () => {
@@ -591,7 +631,7 @@ describe("setup-keys reporting", () => {
   });
 });
 
-describe("what the pane title says about the review", () => {
+describe("review pane titles", () => {
   const titleFor = async (target: Record<string, unknown>) => {
     const reportMetadata = vi.fn();
     const rt = runtime({
@@ -609,7 +649,7 @@ describe("what the pane title says about the review", () => {
     return reportMetadata.mock.calls[0]?.[1]?.title as string | undefined;
   };
 
-  it("shows the comparison base for a branch review, so it is never a guess", async () => {
+  it("shows the comparison base for a branch review", async () => {
     expect(
       await titleFor({ worktree: "/wt/x", mode: "branch", ref: "origin/develop...HEAD" }),
     ).toBe("Review: x — origin/develop...HEAD");

--- a/tests/runtime-actions.test.ts
+++ b/tests/runtime-actions.test.ts
@@ -201,7 +201,7 @@ describe("pane metadata reporting", () => {
     rt.index.upsert({ worktree: "/wt/x", paneId: "w1:p7", sent: [] });
     expect(await dispatch("review", rt as any)).toBe(0);
     expect(reportMetadata).toHaveBeenCalledWith("w1:p7", {
-      title: "Review: x",
+      title: "Review: x — working tree",
       display_agent: "hunk (2 unsent)",
     });
   });
@@ -228,7 +228,7 @@ describe("pane metadata reporting", () => {
     rt.index.upsert({ worktree: "/wt/x", paneId: "w1:p7", sent: ["c1"] });
     await dispatch("review", rt as any);
     expect(reportMetadata).toHaveBeenCalledWith("w1:p7", {
-      title: "Review: x",
+      title: "Review: x — working tree",
       display_agent: "hunk",
     });
   });
@@ -253,7 +253,7 @@ describe("pane metadata reporting", () => {
     });
     await dispatch("review", rt as any);
     expect(reportMetadata).toHaveBeenCalledWith("w2:p9", {
-      title: "Review: x",
+      title: "Review: x — working tree",
       display_agent: "hunk",
     });
   });
@@ -280,7 +280,7 @@ describe("pane metadata reporting", () => {
     rt.index.upsert({ worktree: "/wt/x", paneId: "w1:p7", sent: [] });
     expect(await dispatch("send-review", rt as any)).toBe(0);
     expect(reportMetadata).toHaveBeenCalledWith("w1:p7", {
-      title: "Review: x",
+      title: "Review: x — working tree",
       display_agent: "hunk",
     });
   });
@@ -588,5 +588,41 @@ describe("setup-keys reporting", () => {
 
     expect(code).toBe(1);
     expect(rt.herdr.notify).toHaveBeenCalledWith(expect.stringContaining("Installed 0 of 4"));
+  });
+});
+
+describe("what the pane title says about the review", () => {
+  const titleFor = async (target: Record<string, unknown>) => {
+    const reportMetadata = vi.fn();
+    const rt = runtime({
+      target,
+      herdr: {
+        notify: vi.fn(),
+        promptAgent: vi.fn(() => true),
+        openPane: vi.fn(() => "w1:p7"),
+        closePane: vi.fn(() => true),
+        reportMetadata,
+      },
+    });
+    rt.index.upsert({ worktree: "/wt/x", paneId: "w1:p7", sent: [] });
+    await dispatch("review", rt as any);
+    return reportMetadata.mock.calls[0]?.[1]?.title as string | undefined;
+  };
+
+  it("shows the comparison base for a branch review, so it is never a guess", async () => {
+    expect(
+      await titleFor({ worktree: "/wt/x", mode: "branch", ref: "origin/develop...HEAD" }),
+    ).toBe("Review: x — origin/develop...HEAD");
+  });
+
+  it("distinguishes a working-tree review from a staged one", async () => {
+    expect(await titleFor({ worktree: "/wt/x", mode: "working" })).toBe("Review: x — working tree");
+    expect(await titleFor({ worktree: "/wt/x", mode: "staged" })).toBe("Review: x — staged");
+  });
+
+  it("names the commit under review", async () => {
+    expect(await titleFor({ worktree: "/wt/x", mode: "commit", ref: "abc1234" })).toBe(
+      "Review: x — commit abc1234",
+    );
   });
 });

--- a/tests/target.test.ts
+++ b/tests/target.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULTS } from "../src/config.js";
 import { readContext } from "../src/context.js";
-import { resolveTarget } from "../src/target.js";
+import { describeTarget, resolveTarget } from "../src/target.js";
 
-const deps = (opts: { base?: string | null; ahead?: boolean; root?: string | null }) => ({
+const deps = (opts: {
+  base?: string | null;
+  ahead?: boolean;
+  root?: string | null;
+  dirty?: boolean;
+  exists?: boolean;
+}) => ({
   resolveBaseRef: () => (opts.base === undefined ? "origin/main" : opts.base),
   hasCommitsAhead: () => opts.ahead ?? false,
   repoRoot: (dir: string) => (opts.root === undefined ? dir : opts.root),
+  hasWorkingChanges: () => opts.dirty ?? false,
+  commitExists: () => opts.exists ?? true,
 });
 
 describe("resolveTarget", () => {
@@ -266,5 +274,185 @@ describe("readContext feeding resolveTarget", () => {
       worktree: { checkout_path: "/wt/repo" },
     });
     expect(t.worktree).toBe("/wt/other-repo");
+  });
+});
+
+describe("a configured base", () => {
+  const withBase = (base: string) => ({
+    ...DEFAULTS,
+    review: { ...DEFAULTS.review, base },
+  });
+
+  it("overrides the detected base for an auto branch review", () => {
+    const t = resolveTarget({ worktree: "/wt/x" }, withBase("develop"), deps({ ahead: true }));
+    expect(t.mode).toBe("branch");
+    expect(t.ref).toBe("develop...HEAD");
+  });
+
+  it("overrides the detected base for an explicitly requested branch review", () => {
+    const t = resolveTarget({ worktree: "/wt/x" }, withBase("origin/develop"), deps({}), "branch");
+    expect(t.ref).toBe("origin/develop...HEAD");
+  });
+
+  it("never consults the detector when a configured base resolves", () => {
+    let calls = 0;
+    const t = resolveTarget({ worktree: "/wt/x" }, withBase("develop"), {
+      ...deps({ ahead: true }),
+      resolveBaseRef: () => {
+        calls += 1;
+        return "origin/main";
+      },
+    });
+    expect(t.ref).toBe("develop...HEAD");
+    expect(calls).toBe(0);
+  });
+
+  it("warns and falls back to detection when the configured base does not exist", () => {
+    const t = resolveTarget(
+      { worktree: "/wt/x" },
+      withBase("nope"),
+      deps({ exists: false }),
+      "branch",
+    );
+    expect(t.ref).toBe("origin/main...HEAD");
+    expect(t.warning).toMatch(/nope/);
+  });
+
+  it("names the fallback in the warning so the diff on screen is explained", () => {
+    const t = resolveTarget(
+      { worktree: "/wt/x" },
+      withBase("nope"),
+      deps({ exists: false }),
+      "branch",
+    );
+    expect(t.warning).toMatch(/origin\/main/);
+  });
+
+  it("ignores a blank configured base", () => {
+    const t = resolveTarget({ worktree: "/wt/x" }, withBase("   "), deps({}), "branch");
+    expect(t.ref).toBe("origin/main...HEAD");
+    expect(t.warning).toBeUndefined();
+  });
+
+  it("still prefers a ref supplied by the caller over the configured base", () => {
+    const t = resolveTarget(
+      { worktree: "/wt/x" },
+      withBase("develop"),
+      deps({}),
+      "branch",
+      "main...feature",
+    );
+    expect(t.ref).toBe("main...feature");
+  });
+
+  it("degrades to the working tree with a warning when neither the configured base nor detection resolves", () => {
+    const t = resolveTarget(
+      { worktree: "/wt/x" },
+      withBase("nope"),
+      deps({ base: null, exists: false }),
+      "branch",
+    );
+    expect(t.mode).toBe("working");
+    expect(t.warning).toMatch(/base/i);
+  });
+});
+
+describe("auto precedence", () => {
+  it("prefers the working tree when it is dirty, even with commits ahead of the base", () => {
+    const t = resolveTarget({ worktree: "/wt/x" }, DEFAULTS, deps({ ahead: true, dirty: true }));
+    expect(t.mode).toBe("working");
+    expect(t.ref).toBeUndefined();
+  });
+
+  it("picks the branch diff when the working tree is clean and the branch is ahead", () => {
+    const t = resolveTarget({ worktree: "/wt/x" }, DEFAULTS, deps({ ahead: true, dirty: false }));
+    expect(t.mode).toBe("branch");
+    expect(t.ref).toBe("origin/main...HEAD");
+  });
+
+  it("never consults the base detector when the working tree is dirty", () => {
+    let calls = 0;
+    resolveTarget({ worktree: "/wt/x" }, DEFAULTS, {
+      ...deps({ dirty: true }),
+      resolveBaseRef: () => {
+        calls += 1;
+        return "origin/main";
+      },
+    });
+    expect(calls).toBe(0);
+  });
+
+  it("counts untracked files as working changes by default", () => {
+    let includeUntracked: boolean | undefined;
+    resolveTarget({ worktree: "/wt/x" }, DEFAULTS, {
+      ...deps({}),
+      hasWorkingChanges: (_repo: string, include: boolean) => {
+        includeUntracked = include;
+        return false;
+      },
+    });
+    expect(includeUntracked).toBe(true);
+  });
+
+  it("ignores untracked files when review.exclude_untracked is set", () => {
+    let includeUntracked: boolean | undefined;
+    const cfg = { ...DEFAULTS, review: { ...DEFAULTS.review, exclude_untracked: true } };
+    resolveTarget({ worktree: "/wt/x" }, cfg, {
+      ...deps({}),
+      hasWorkingChanges: (_repo: string, include: boolean) => {
+        includeUntracked = include;
+        return false;
+      },
+    });
+    expect(includeUntracked).toBe(false);
+  });
+
+  it("does not consult the working tree for an explicitly requested mode", () => {
+    let calls = 0;
+    const counting = {
+      ...deps({ ahead: true }),
+      hasWorkingChanges: () => {
+        calls += 1;
+        return true;
+      },
+    };
+    for (const mode of ["working", "staged", "branch", "commit", "stash"] as const) {
+      resolveTarget({ worktree: "/wt/x" }, DEFAULTS, counting, mode);
+    }
+    expect(calls).toBe(0);
+  });
+});
+
+describe("describeTarget", () => {
+  it("names the working tree", () => {
+    expect(describeTarget({ worktree: "/wt/x", mode: "working" })).toBe("working tree");
+  });
+
+  it("names staged changes", () => {
+    expect(describeTarget({ worktree: "/wt/x", mode: "staged" })).toBe("staged");
+  });
+
+  it("shows the branch range so the comparison base is visible", () => {
+    expect(describeTarget({ worktree: "/wt/x", mode: "branch", ref: "origin/main...HEAD" })).toBe(
+      "origin/main...HEAD",
+    );
+  });
+
+  it("falls back to a plain label for a branch target with no range", () => {
+    expect(describeTarget({ worktree: "/wt/x", mode: "branch" })).toBe("branch");
+  });
+
+  it("names a commit review, with and without a ref", () => {
+    expect(describeTarget({ worktree: "/wt/x", mode: "commit", ref: "abc1234" })).toBe(
+      "commit abc1234",
+    );
+    expect(describeTarget({ worktree: "/wt/x", mode: "commit" })).toBe("last commit");
+  });
+
+  it("names a stash review, with and without a ref", () => {
+    expect(describeTarget({ worktree: "/wt/x", mode: "stash", ref: "stash@{1}" })).toBe(
+      "stash@{1}",
+    );
+    expect(describeTarget({ worktree: "/wt/x", mode: "stash" })).toBe("latest stash");
   });
 });


### PR DESCRIPTION
Fixes #8 and #15.

- Prefer uncommitted changes in `auto` mode; use `<base>...HEAD` only when the tree is clean and ahead of its base. `exclude_untracked` also controls target selection.
- Add `review.base` to override base detection, with a warning and fallback for invalid refs.
- Show the active target in pane titles and keep it accurate across reloads, automatic reviews, and comment delivery.

Behavior change: dirty branches now open a working-tree review by default. Set `review.default_target = "branch"` to always review the branch diff.

Validation: 705 tests passed, including real Git coverage; formatting, lint, TypeScript build, and dependency audit passed.
