### PR TITLE
build: support npm and pnpm plugin installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,43 @@ jobs:
 
       - name: Test
         run: npm test
+
+  # The plugin builds on the user's machine, so the non-npm install path needs its own coverage.
+  pnpm:
+    name: pnpm build path
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Install pnpm
+        run: npm install --global pnpm
+
+      - name: Install dependencies the way the manifest does
+        env:
+          HUNKDIFF_PACKAGE_MANAGER: pnpm
+        run: node scripts/install-deps.mjs
+
+      - name: Build the way the manifest does
+        env:
+          HUNKDIFF_PACKAGE_MANAGER: pnpm
+        run: node scripts/run-script.mjs build
+
+      # pnpm's symlinked layout is what could break this path; the launcher hardcodes it.
+      - name: Launch hunk through the path resolveHunkLauncher builds
+        run: |
+          pinned="$(node -p "require('./package.json').dependencies.hunkdiff")"
+          actual="$(node node_modules/hunkdiff/bin/hunk.cjs --version)"
+          echo "pinned=$pinned actual=$actual"
+          test "$pinned" = "$actual"
+
+      - name: Test
+        env:
+          HUNKDIFF_PACKAGE_MANAGER: pnpm
+        run: node scripts/run-script.mjs test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/install-deps.mjs
 
       - name: Audit dependencies
         if: matrix.os == 'ubuntu-latest' && matrix.node == '24'
@@ -48,15 +48,21 @@ jobs:
         run: npm run check
 
       - name: Build
-        run: npm run build
+        run: node scripts/run-script.mjs build
 
       - name: Test
         run: npm test
 
-  # The plugin builds on the user's machine, so the non-npm install path needs its own coverage.
   pnpm:
-    name: pnpm build path
-    runs-on: ubuntu-latest
+    name: pnpm ${{ matrix.pnpm }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        pnpm: ["10", "12"]
+    env:
+      HUNKDIFF_PACKAGE_MANAGER: pnpm
 
     steps:
       - name: Check out repository
@@ -68,27 +74,24 @@ jobs:
           node-version: "24"
 
       - name: Install pnpm
-        run: npm install --global pnpm
+        run: npm install --global pnpm@${{ matrix.pnpm }}
 
-      - name: Install dependencies the way the manifest does
-        env:
-          HUNKDIFF_PACKAGE_MANAGER: pnpm
+      - name: Install dependencies
         run: node scripts/install-deps.mjs
 
-      - name: Build the way the manifest does
-        env:
-          HUNKDIFF_PACKAGE_MANAGER: pnpm
+      - name: Build
         run: node scripts/run-script.mjs build
 
-      # pnpm's symlinked layout is what could break this path; the launcher hardcodes it.
-      - name: Launch hunk through the path resolveHunkLauncher builds
-        run: |
-          pinned="$(node -p "require('./package.json').dependencies.hunkdiff")"
-          actual="$(node node_modules/hunkdiff/bin/hunk.cjs --version)"
-          echo "pinned=$pinned actual=$actual"
-          test "$pinned" = "$actual"
+      - name: Verify bundled Hunk launcher
+        run: >-
+          node --input-type=module -e '
+          import { execFileSync } from "node:child_process";
+          import { readFileSync } from "node:fs";
+          import assert from "node:assert/strict";
+          const pinned = JSON.parse(readFileSync("package.json", "utf8")).dependencies.hunkdiff;
+          const actual = execFileSync(process.execPath, ["node_modules/hunkdiff/bin/hunk.cjs", "--version"], { encoding: "utf8" }).trim();
+          assert.equal(actual, pinned);
+          console.log("Hunk " + actual);'
 
       - name: Test
-        env:
-          HUNKDIFF_PACKAGE_MANAGER: pnpm
         run: node scripts/run-script.mjs test

--- a/README.md
+++ b/README.md
@@ -38,17 +38,13 @@ https://github.com/user-attachments/assets/a36991a9-288f-4c8a-845c-ce2399334b9b
 | ------------------- | ----------------------------------------- |
 | **herdr**           | 0.8.0 or newer on macOS, Linux or Windows |
 | **Node**            | 22.12 or newer                            |
-| **npm** or **pnpm** | Any version, to build the plugin          |
+| **npm** or **pnpm** | npm 10+ or pnpm 10+                       |
 
 The plugin installs its pinned `hunkdiff` dependency automatically. You do not need a global hunk
 installation for reviews opened inside herdr.
 
-`herdr plugin install` builds the plugin on your machine, which needs a package manager. npm is used
-when it is available, because `package-lock.json` pins the exact dependency tree CI verified;
-otherwise pnpm is used, which resolves the declared ranges instead. The pnpm install passes
-`--ignore-scripts`, since no dependency needs a postinstall and pnpm 12 fails an install that skips
-one. `hunkdiff` is pinned to an exact version in `package.json`, so the reviewer itself is identical
-either way. Force one with:
+Installation uses npm when available, falling back to pnpm. Set `HUNKDIFF_PACKAGE_MANAGER`
+to `npm` or `pnpm` to choose explicitly:
 
 ```bash
 HUNKDIFF_PACKAGE_MANAGER=pnpm herdr plugin install jhochenbaum/herdr-hunk-diff
@@ -450,11 +446,22 @@ npm run build
 npm test
 ```
 
-pnpm works too — `pnpm install` in place of `npm ci`. Contributions should keep `package-lock.json`
-current, since it is what the release build and CI pin against.
+For pnpm:
 
-CI runs formatting, linting, TypeScript compilation, tests, and a high-severity dependency audit,
-plus a job that installs and builds through pnpm so the non-npm path stays working.
+```bash
+pnpm install --ignore-scripts
+pnpm run format:check
+pnpm run lint
+pnpm run build
+pnpm test
+```
+
+Keep `package-lock.json` current when changing dependencies. npm installs use this lockfile;
+pnpm resolves the ranges in `package.json`. Both use the same pinned Hunk version.
+The pnpm path skips dependency build scripts and uses Hunk's prebuilt platform binary.
+
+CI checks formatting, lint, TypeScript compilation, tests, and dependency vulnerabilities.
+It also verifies installation, builds, and the Hunk launcher with npm and pnpm on Linux and Windows.
 
 ## Prior art
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ installation for reviews opened inside herdr.
 
 `herdr plugin install` builds the plugin on your machine, which needs a package manager. npm is used
 when it is available, because `package-lock.json` pins the exact dependency tree CI verified;
-otherwise pnpm is used, which resolves the declared ranges instead. `hunkdiff` is pinned to an exact
-version in `package.json`, so the reviewer itself is identical either way. Force one with:
+otherwise pnpm is used, which resolves the declared ranges instead. The pnpm install passes
+`--ignore-scripts`, since no dependency needs a postinstall and pnpm 12 fails an install that skips
+one. `hunkdiff` is pinned to an exact version in `package.json`, so the reviewer itself is identical
+either way. Force one with:
 
 ```bash
 HUNKDIFF_PACKAGE_MANAGER=pnpm herdr plugin install jhochenbaum/herdr-hunk-diff

--- a/README.md
+++ b/README.md
@@ -34,13 +34,23 @@ https://github.com/user-attachments/assets/a36991a9-288f-4c8a-845c-ce2399334b9b
 
 ## Requirements
 
-| Name      | Version                                   |
-| --------- | ----------------------------------------- |
-| **herdr** | 0.8.0 or newer on macOS, Linux or Windows |
-| **Node**  | 22.12 or newer                            |
+| Name                | Version                                   |
+| ------------------- | ----------------------------------------- |
+| **herdr**           | 0.8.0 or newer on macOS, Linux or Windows |
+| **Node**            | 22.12 or newer                            |
+| **npm** or **pnpm** | Any version, to build the plugin          |
 
 The plugin installs its pinned `hunkdiff` dependency automatically. You do not need a global hunk
 installation for reviews opened inside herdr.
+
+`herdr plugin install` builds the plugin on your machine, which needs a package manager. npm is used
+when it is available, because `package-lock.json` pins the exact dependency tree CI verified;
+otherwise pnpm is used, which resolves the declared ranges instead. `hunkdiff` is pinned to an exact
+version in `package.json`, so the reviewer itself is identical either way. Force one with:
+
+```bash
+HUNKDIFF_PACKAGE_MANAGER=pnpm herdr plugin install jhochenbaum/herdr-hunk-diff
+```
 
 On Windows, hunk ships prebuilt binaries for x64 only, so reviews cannot open on Windows on ARM
 unless `[hunk].bin` points at a hunk you built yourself. Everything else — actions, keybindings and
@@ -438,7 +448,11 @@ npm run build
 npm test
 ```
 
-CI runs formatting, linting, TypeScript compilation, tests, and a high-severity dependency audit.
+pnpm works too — `pnpm install` in place of `npm ci`. Contributions should keep `package-lock.json`
+current, since it is what the release build and CI pin against.
+
+CI runs formatting, linting, TypeScript compilation, tests, and a high-severity dependency audit,
+plus a job that installs and builds through pnpm so the non-npm path stays working.
 
 ## Prior art
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    files: ["**/*.{js,ts}"],
+    files: ["**/*.{js,mjs,ts}"],
     languageOptions: {
       globals: globals.node,
     },

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -7,8 +7,7 @@ min_herdr_version = "0.8.0"
 description = "Review agent-authored diffs in hunk, and send your inline comments back to the agent that wrote them."
 platforms = ["macos", "linux", "windows"]
 
-# Build steps inherit the top-level platforms. They dispatch through node rather than naming a
-# package manager, so a machine with pnpm but no npm can still build the plugin.
+# Build steps inherit the top-level platforms.
 [[build]]
 command = ["node", "scripts/install-deps.mjs"]
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -7,12 +7,13 @@ min_herdr_version = "0.8.0"
 description = "Review agent-authored diffs in hunk, and send your inline comments back to the agent that wrote them."
 platforms = ["macos", "linux", "windows"]
 
-# Build steps inherit the top-level platforms.
+# Build steps inherit the top-level platforms. They dispatch through node rather than naming a
+# package manager, so a machine with pnpm but no npm can still build the plugin.
 [[build]]
-command = ["npm", "ci"]
+command = ["node", "scripts/install-deps.mjs"]
 
 [[build]]
-command = ["npm", "run", "build"]
+command = ["node", "scripts/run-script.mjs", "build"]
 
 # Global socket subscriptions require a pane id, so each event runs a short-lived manifest hook.
 # Herdr runs hooks from the plugin root, so direct argv needs no shell expansion.

--- a/scripts/install-deps.mjs
+++ b/scripts/install-deps.mjs
@@ -1,4 +1,3 @@
-// Build step 1: install dependencies with whichever supported package manager is present.
 import { detect, MANAGERS, run } from "./package-manager.mjs";
 
 const manager = detect();

--- a/scripts/install-deps.mjs
+++ b/scripts/install-deps.mjs
@@ -1,0 +1,7 @@
+// Build step 1: install dependencies with whichever supported package manager is present.
+import { detect, MANAGERS, run } from "./package-manager.mjs";
+
+const manager = detect();
+const args = MANAGERS[manager].install;
+console.log(`hunkdiff: installing dependencies with \`${manager} ${args.join(" ")}\``);
+process.exit(run(manager, args).status ?? 1);

--- a/scripts/package-manager.mjs
+++ b/scripts/package-manager.mjs
@@ -10,7 +10,9 @@ export const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 /** Frozen installs first: they reproduce a lockfile instead of re-resolving ranges. */
 export const MANAGERS = {
   npm: { install: existsSync(join(ROOT, "package-lock.json")) ? ["ci"] : ["install"] },
-  pnpm: { install: ["install"] },
+  // pnpm blocks dependency build scripts and, since pnpm 12, fails the install over them. Asking
+  // for it explicitly succeeds: hunk runs its prebuilt binary, so no dependency needs a postinstall.
+  pnpm: { install: ["install", "--ignore-scripts"] },
 };
 
 export const OVERRIDE = "HUNKDIFF_PACKAGE_MANAGER";

--- a/scripts/package-manager.mjs
+++ b/scripts/package-manager.mjs
@@ -1,0 +1,60 @@
+// Picks the package manager the plugin builds with. npm is preferred because package-lock.json is
+// the tree CI verifies; other managers re-resolve ranges, so they are a fallback, not a default.
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/** Frozen installs first: they reproduce a lockfile instead of re-resolving ranges. */
+export const MANAGERS = {
+  npm: { install: existsSync(join(ROOT, "package-lock.json")) ? ["ci"] : ["install"] },
+  pnpm: { install: ["install"] },
+};
+
+export const OVERRIDE = "HUNKDIFF_PACKAGE_MANAGER";
+
+/** Windows resolves `npm`/`pnpm` through .cmd shims, which need a shell to execute. */
+export const SHELL = process.platform === "win32";
+
+export function run(manager, args) {
+  return spawnSync(manager, args, { cwd: ROOT, stdio: "inherit", shell: SHELL });
+}
+
+// `--version` rather than a PATH lookup, so a shim that cannot actually run is not chosen.
+function usable(bin) {
+  return spawnSync(bin, ["--version"], { stdio: "ignore", shell: SHELL }).status === 0;
+}
+
+const supported = () => Object.keys(MANAGERS).join(", ");
+const eitherOf = () => Object.keys(MANAGERS).join(" or ");
+
+/** Resolves the manager to use, or exits with a message naming what the machine would accept. */
+export function detect() {
+  const requested = process.env[OVERRIDE]?.trim();
+  if (requested) {
+    if (!(requested in MANAGERS)) {
+      console.error(
+        `hunkdiff: ${OVERRIDE}="${requested}" is not supported; use one of ${supported()}.`,
+      );
+      process.exit(1);
+    }
+    if (!usable(requested)) {
+      console.error(
+        `hunkdiff: ${OVERRIDE}="${requested}" was requested, but ${requested} did not run.`,
+      );
+      process.exit(1);
+    }
+    return requested;
+  }
+
+  const found = Object.keys(MANAGERS).find(usable);
+  if (!found) {
+    console.error(
+      `hunkdiff: no supported package manager found. Install ${eitherOf()}, or set ${OVERRIDE}.`,
+    );
+    process.exit(1);
+  }
+  return found;
+}

--- a/scripts/package-manager.mjs
+++ b/scripts/package-manager.mjs
@@ -1,5 +1,3 @@
-// Picks the package manager the plugin builds with. npm is preferred because package-lock.json is
-// the tree CI verifies; other managers re-resolve ranges, so they are a fallback, not a default.
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -7,18 +5,17 @@ import { fileURLToPath } from "node:url";
 
 export const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 
-/** Frozen installs first: they reproduce a lockfile instead of re-resolving ranges. */
+// Prefer the committed npm lockfile.
 export const MANAGERS = {
   npm: { install: existsSync(join(ROOT, "package-lock.json")) ? ["ci"] : ["install"] },
-  // pnpm blocks dependency build scripts and, since pnpm 12, fails the install over them. Asking
-  // for it explicitly succeeds: hunk runs its prebuilt binary, so no dependency needs a postinstall.
+  // Hunk uses a prebuilt binary; pnpm 12 requires explicitly skipping dependency scripts.
   pnpm: { install: ["install", "--ignore-scripts"] },
 };
 
-export const OVERRIDE = "HUNKDIFF_PACKAGE_MANAGER";
+const OVERRIDE = "HUNKDIFF_PACKAGE_MANAGER";
 
 /** Windows resolves `npm`/`pnpm` through .cmd shims, which need a shell to execute. */
-export const SHELL = process.platform === "win32";
+const SHELL = process.platform === "win32";
 
 export function run(manager, args) {
   return spawnSync(manager, args, { cwd: ROOT, stdio: "inherit", shell: SHELL });
@@ -36,7 +33,7 @@ const eitherOf = () => Object.keys(MANAGERS).join(" or ");
 export function detect() {
   const requested = process.env[OVERRIDE]?.trim();
   if (requested) {
-    if (!(requested in MANAGERS)) {
+    if (!Object.hasOwn(MANAGERS, requested)) {
       console.error(
         `hunkdiff: ${OVERRIDE}="${requested}" is not supported; use one of ${supported()}.`,
       );

--- a/scripts/run-script.mjs
+++ b/scripts/run-script.mjs
@@ -1,0 +1,13 @@
+// Build step 2: run a package.json script through the detected package manager, so the manifest
+// never hardcodes one. Keeps package.json the single source of truth for what building means.
+import { detect, run } from "./package-manager.mjs";
+
+const script = process.argv[2];
+if (!script) {
+  console.error("hunkdiff: run-script.mjs needs a package.json script name");
+  process.exit(1);
+}
+
+const manager = detect();
+console.log(`hunkdiff: running \`${manager} run ${script}\``);
+process.exit(run(manager, ["run", script]).status ?? 1);

--- a/scripts/run-script.mjs
+++ b/scripts/run-script.mjs
@@ -1,10 +1,17 @@
-// Build step 2: run a package.json script through the detected package manager, so the manifest
-// never hardcodes one. Keeps package.json the single source of truth for what building means.
-import { detect, run } from "./package-manager.mjs";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { detect, ROOT, run } from "./package-manager.mjs";
 
 const script = process.argv[2];
 if (!script) {
   console.error("hunkdiff: run-script.mjs needs a package.json script name");
+  process.exit(1);
+}
+
+const { scripts } = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+// Script names become shell arguments on Windows.
+if (!/^[a-zA-Z0-9][a-zA-Z0-9:_-]*$/.test(script) || !Object.hasOwn(scripts ?? {}, script)) {
+  console.error(`hunkdiff: unknown or invalid package.json script: ${script}`);
   process.exit(1);
 }
 

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { parse } from "smol-toml";
 import {
   paneEntrypointFor,
@@ -96,7 +96,23 @@ describe("herdr-plugin.toml", () => {
   });
 
   it("declares a build step that installs dependencies", () => {
-    expect(manifest.build.some((b: any) => b.command.includes("ci"))).toBe(true);
+    expect(manifest.build.some((b: any) => b.command.join(" ").includes("install-deps"))).toBe(
+      true,
+    );
+  });
+
+  it("names no package manager in a build step, so pnpm-only machines can build", () => {
+    for (const step of manifest.build) {
+      expect(step.command[0]).toBe("node");
+      expect(step.command.join(" ")).not.toMatch(/\b(npm|pnpm|yarn|bun)\b/);
+    }
+  });
+
+  it("runs every build step through a script that exists", () => {
+    for (const step of manifest.build) {
+      const script = step.command.find((c: string) => c.endsWith(".mjs"));
+      expect(existsSync(script), script).toBe(true);
+    }
   });
 
   it("declares the review pane as a split by default", () => {

--- a/tests/package-manager.test.ts
+++ b/tests/package-manager.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const temporary: string[] = [];
+afterEach(() => {
+  for (const dir of temporary.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function fixture(managers: Record<string, { versionStatus?: number; runStatus?: number }> = {}) {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "hunk build ")));
+  temporary.push(dir);
+  const root = join(dir, "plugin");
+  const bin = join(dir, "bin");
+  mkdirSync(root);
+  mkdirSync(bin);
+  cpSync("scripts", join(root, "scripts"), { recursive: true });
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({ scripts: { build: "tsc", test: "vitest" } }),
+  );
+  writeFileSync(join(root, "package-lock.json"), "{}");
+  const log = join(dir, "calls.jsonl");
+  const helper = join(dir, "manager.cjs");
+  writeFileSync(
+    helper,
+    `
+    const fs = require("node:fs");
+    const [manager, ...args] = process.argv.slice(2);
+    const config = ${JSON.stringify(managers)}[manager];
+    fs.appendFileSync(${JSON.stringify(log)}, JSON.stringify({ manager, args, cwd: process.cwd() }) + "\\n");
+    process.exit(args[0] === "--version" ? (config.versionStatus ?? 0) : (config.runStatus ?? 0));
+  `,
+  );
+  const quote = (text: string) => `'${text.replaceAll("'", "'\\''")}'`;
+  for (const manager of Object.keys(managers)) {
+    if (process.platform === "win32") {
+      writeFileSync(
+        join(bin, `${manager}.cmd`),
+        `@echo off\r\n"${process.execPath}" "${helper}" ${manager} %*\r\n`,
+      );
+    } else {
+      writeFileSync(
+        join(bin, manager),
+        `#!/bin/sh\nexec ${quote(process.execPath)} ${quote(helper)} ${quote(manager)} "$@"\n`,
+        { mode: 0o755 },
+      );
+    }
+  }
+  return {
+    root,
+    run(script = "install-deps.mjs", args: string[] = [], override = "") {
+      const env = { ...process.env };
+      for (const key of Object.keys(env)) if (key.toLowerCase() === "path") delete env[key];
+      return spawnSync(process.execPath, [join(root, "scripts", script), ...args], {
+        cwd: dir,
+        encoding: "utf8",
+        env: { ...env, PATH: bin, HUNKDIFF_PACKAGE_MANAGER: override },
+      });
+    },
+    calls(): Array<{ manager: string; args: string[]; cwd: string }> {
+      try {
+        return readFileSync(log, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+      } catch {
+        return [];
+      }
+    },
+  };
+}
+
+describe("package manager build scripts", () => {
+  it("prefers npm ci and runs in the plugin root from another directory", () => {
+    const f = fixture({ npm: {}, pnpm: {} });
+    expect(f.run().status).toBe(0);
+    expect(f.calls().at(-1)).toEqual({ manager: "npm", args: ["ci"], cwd: f.root });
+    expect(f.calls().some((call) => call.manager === "pnpm")).toBe(false);
+  });
+
+  it.each([{}, { npm: { versionStatus: 1 } }])(
+    "falls back to pnpm when npm cannot run (%j)",
+    (other) => {
+      const f = fixture({ ...other, pnpm: {} });
+      expect(f.run().status).toBe(0);
+      expect(f.calls().at(-1)).toEqual({
+        manager: "pnpm",
+        args: ["install", "--ignore-scripts"],
+        cwd: f.root,
+      });
+    },
+  );
+
+  it("honors an explicit pnpm override even when npm is available", () => {
+    const f = fixture({ npm: {}, pnpm: {} });
+    expect(f.run("install-deps.mjs", [], " pnpm ").status).toBe(0);
+    expect(f.calls().every((call) => call.manager === "pnpm")).toBe(true);
+  });
+
+  it("fails when the explicitly requested manager is unavailable", () => {
+    const f = fixture({ pnpm: {} });
+    const result = f.run("install-deps.mjs", [], "npm");
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("npm did not run");
+    expect(f.calls()).toEqual([]);
+  });
+
+  it.each(["yarn", "constructor", "toString", "__proto__"])(
+    "rejects unsupported manager %s before executing it",
+    (manager) => {
+      const f = fixture({ [manager]: {} });
+      const result = f.run("install-deps.mjs", [], manager);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("is not supported");
+      expect(f.calls()).toEqual([]);
+    },
+  );
+
+  it("names the supported managers when neither is installed", () => {
+    const result = fixture().run();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Install npm or pnpm");
+  });
+
+  it("propagates install failure without retrying a different manager", () => {
+    const f = fixture({ npm: { runStatus: 7 }, pnpm: {} });
+    expect(f.run().status).toBe(7);
+    expect(f.calls().some((call) => call.manager === "pnpm")).toBe(false);
+  });
+
+  it("runs the requested build script through pnpm and propagates its status", () => {
+    const f = fixture({ pnpm: { runStatus: 3 } });
+    expect(f.run("run-script.mjs", ["build"]).status).toBe(3);
+    expect(f.calls().at(-1)).toEqual({ manager: "pnpm", args: ["run", "build"], cwd: f.root });
+  });
+
+  it.each([[], ["unknown"], ["build&echo injected"], ["--help"]])(
+    "rejects missing or invalid script arguments %j",
+    (...args) => {
+      const f = fixture({ npm: {} });
+      expect(f.run("run-script.mjs", args).status).toBe(1);
+      expect(f.calls()).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
Fixes #16.

Build the plugin with npm when available, falling back to pnpm. `HUNKDIFF_PACKAGE_MANAGER=npm|pnpm` selects a manager explicitly.

npm uses `package-lock.json`; pnpm resolves the declared dependency ranges with dependency scripts disabled. Both use the pinned Hunk version and its prebuilt platform binary.

Add process-level tests for manager selection, invalid input, exit codes, and paths containing spaces. CI exercises the manifest build steps with npm and pnpm 10/12 on Linux and Windows, including the bundled Hunk launcher.

Validation: 686 local tests passed, plus a clean install/build/test with npm absent from PATH. Formatting, lint, TypeScript build, workflow validation, and dependency audit passed. The combined tree with #22 merges cleanly and passes 723 tests.
