### PR TITLE
chore(release): prepare 0.3.0

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "jhochenbaum.hunkdiff"
 name = "hunk"
-version = "0.2.1"
+version = "0.3.0"
 
 # Requires plugin-root-relative action commands and reliable agent prompt submission from Herdr 0.8.
 min_herdr_version = "0.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "herdr-hunk-diff",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herdr-hunk-diff",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "hunkdiff": "0.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herdr-hunk-diff",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A herdr plugin that reviews agent-authored diffs in hunk and sends your inline comments back to the agent that wrote them.",
   "license": "MIT",
   "author": "Jordan Hochenbaum",


### PR DESCRIPTION
Prepare v0.3.0 for #22 and #23. Update the plugin manifest, package metadata, and lockfile version together.

This is a minor release because `auto` now prioritizes uncommitted changes. It also adds `review.base`, accurate target titles, and pnpm installation support.

Validation: 723 tests passed; formatting, lint, TypeScript build, and dependency audit passed.

Merge this PR before publishing the [draft v0.3.0 release](https://github.com/jhochenbaum/herdr-hunk-diff/releases/tag/untagged-839e3e35d6ec4feb0f6b) from `main`.
