### PR TITLE
feat: run hunk inside a Docker Sandbox when the worktree lives there

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,15 @@ a separately installed binary.
 agent notes. `extra_args` appends string arguments to every hunk launch. If any list item is not a
 string, the entire list is rejected to avoid constructing a partial command.
 
+With `bin = "auto"`, if the review's worktree does not exist on this filesystem — for example, an
+agent working inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) `--clone` checkout
+that never left the container — the plugin looks for a sandbox whose workspace contains that path
+(via `sbx ls --json`) and runs hunk there instead, through `sbx exec <sandbox> -- hunk`. This
+assumes hunk is installed globally inside the sandbox (see
+[Optional VCS pager setup](#optional-vcs-pager-setup)). Any failure along that path — `sbx` not
+installed, no matching sandbox, an unreadable `sbx ls` response — falls back to the bundled local
+hunk unchanged.
+
 ## Optional VCS pager setup
 
 Pager setup is independent of reviews inside herdr. It makes commands such as `git diff`, `git log`,

--- a/src/bin/event.ts
+++ b/src/bin/event.ts
@@ -18,8 +18,13 @@ const defaultDeps: EventBinDeps = {
   buildDeps: (env) => {
     const herdr = new HerdrAdapter(env.HERDR_BIN_PATH ?? "herdr");
     const cfg = loadConfig(env.HERDR_PLUGIN_CONFIG_DIR ?? ".");
-    const launcher = resolveHunkLauncher(cfg, env.HERDR_PLUGIN_ROOT ?? process.cwd());
-    const hunk = new HunkAdapter(launcher.bin, launcher.prefix);
+    const pluginRoot = env.HERDR_PLUGIN_ROOT ?? process.cwd();
+    // Resolved per worktree: which launcher applies can differ across the events one process
+    // may see, and the choice depends on that worktree's own resolution (see resolveHunkLauncher).
+    const hunkFor = (worktree: string): HunkAdapter => {
+      const launcher = resolveHunkLauncher(cfg, pluginRoot, worktree);
+      return new HunkAdapter(launcher.bin, launcher.prefix);
+    };
     const index = new ReviewIndex(env.HERDR_PLUGIN_STATE_DIR ?? ".");
     return {
       cfg,
@@ -28,8 +33,9 @@ const defaultDeps: EventBinDeps = {
       worktreeForPane: worktreeForPaneVia(herdr, (dir) => repoRoot(dir, realRunner(dir))),
       resolveTarget: (worktree) =>
         resolveTarget({ cwd: worktree }, cfg, realTargetDeps(realRunner)),
-      reloadReview: (target) => hunk.reload(target.worktree, target, cfg),
-      reportReviewMetadata: (worktree) => reportReviewMetadata({ index, herdr, hunk }, worktree),
+      reloadReview: (target) => hunkFor(target.worktree).reload(target.worktree, target, cfg),
+      reportReviewMetadata: (worktree) =>
+        reportReviewMetadata({ index, herdr, hunk: hunkFor(worktree) }, worktree),
     };
   },
 };

--- a/src/bin/pane.ts
+++ b/src/bin/pane.ts
@@ -56,7 +56,7 @@ export function resolveAndRun(
     sidecar = undefined;
   }
 
-  const launcher = resolveHunkLauncher(cfg, env.HERDR_PLUGIN_ROOT ?? cwd);
+  const launcher = resolveHunkLauncher(cfg, env.HERDR_PLUGIN_ROOT ?? cwd, target.worktree);
   const result = spawn(
     launcher.bin,
     [...launcher.prefix, ...buildLaunchArgs(target, cfg, sidecar)],

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { Placement, PluginConfig } from "./config.js";
 import { asObject, asString, parseJsonObject, type JsonObject } from "./json.js";
 import { PLUGIN_ID } from "./keys.js";
+import { findSandboxForPath, realSandboxLookup, type SandboxLookup } from "./sandbox.js";
 
 export type CliRunner = (args: string[]) => { status: number; stdout: string };
 
@@ -26,17 +27,36 @@ export interface HunkLauncher {
   prefix: string[];
 }
 
-/** Runs the bundled launcher with Node, bypassing platform-specific npm shims. */
+/**
+ * Runs the bundled launcher with Node, bypassing platform-specific npm shims. When `worktree`
+ * does not exist on this filesystem, the review most likely lives inside a Docker Sandbox whose
+ * checkout never left the container (e.g. a `--clone` sandbox). In that case, look for a sandbox
+ * whose workspace contains it and route the call through `sbx exec` instead, assuming a global
+ * `hunk` install inside the sandbox (see README's pager setup section). Any failure along that
+ * path — `sbx` missing, no matching sandbox, a malformed `sbx ls` response — falls back to the
+ * bundled local launcher unchanged.
+ */
 export function resolveHunkLauncher(
   cfg: PluginConfig,
   pluginRoot: string,
+  worktree: string,
   execPath: string = process.execPath,
+  lookup: SandboxLookup = realSandboxLookup,
 ): HunkLauncher {
   if (cfg.hunk.bin !== "auto") return { bin: cfg.hunk.bin, prefix: [] };
-  return {
+
+  const local: HunkLauncher = {
     bin: execPath,
     prefix: [join(pluginRoot, "node_modules", "hunkdiff", "bin", "hunk.cjs")],
   };
+
+  try {
+    if (lookup.exists(worktree)) return local;
+    const sandbox = findSandboxForPath(worktree, lookup.listSandboxes());
+    return sandbox ? { bin: "sbx", prefix: ["exec", sandbox, "hunk"] } : local;
+  } catch {
+    return local;
+  }
 }
 
 export class HerdrAdapter {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -52,7 +52,7 @@ export function buildRuntime(env: NodeJS.ProcessEnv): Runtime {
   };
 
   const stateDir = env.HERDR_PLUGIN_STATE_DIR ?? ".";
-  const hunkLauncher = resolveHunkLauncher(cfg, pluginRoot);
+  let hunkAdapter: HunkAdapter | undefined;
 
   return {
     cfg,
@@ -61,7 +61,15 @@ export function buildRuntime(env: NodeJS.ProcessEnv): Runtime {
     stateDir,
     index: new ReviewIndex(stateDir),
     herdr: new HerdrAdapter(env.HERDR_BIN_PATH ?? "herdr"),
-    hunk: new HunkAdapter(hunkLauncher.bin, hunkLauncher.prefix),
+    // Deferred: choosing a launcher needs the resolved worktree, and resolving it must not
+    // force a git subprocess for actions that never touch hunk (see runtime-lazy-target.test.ts).
+    get hunk(): Pick<HunkAdapter, "listComments" | "removeComment" | "reload" | "navigate"> {
+      if (!hunkAdapter) {
+        const launcher = resolveHunkLauncher(cfg, pluginRoot, targetFor().worktree);
+        hunkAdapter = new HunkAdapter(launcher.bin, launcher.prefix);
+      }
+      return hunkAdapter;
+    },
     targetFor,
     commitExists: (repo, ref) => commitExists(repo, ref, realRunner(repo)),
     get target(): Target {

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -1,0 +1,65 @@
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { isAbsolute, relative, resolve } from "node:path";
+
+export interface SandboxInfo {
+  name: string;
+  /** Host-visible workspace path `sbx ls` reports for this sandbox, when it has one. */
+  workspace?: string;
+}
+
+export interface SandboxLookup {
+  /** True when `path` exists on the filesystem the plugin process itself runs on. */
+  exists: (path: string) => boolean;
+  /** Lists sandboxes known to `sbx`. Returns `[]` when `sbx` is unavailable or reports none. */
+  listSandboxes: () => SandboxInfo[];
+}
+
+/** Uses path semantics so sibling prefixes such as `/wt/a` and `/wt/ab` do not collide. */
+function containsPath(outer: string, inner: string): boolean {
+  const rel = relative(resolve(outer), resolve(inner));
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+/** Picks the sandbox whose workspace contains `path`, preferring the most specific match. */
+export function findSandboxForPath(path: string, sandboxes: SandboxInfo[]): string | undefined {
+  const candidates = sandboxes.filter(
+    (s): s is SandboxInfo & { workspace: string } =>
+      typeof s.workspace === "string" && s.workspace.length > 0 && containsPath(s.workspace, path),
+  );
+  if (candidates.length === 0) return undefined;
+  return candidates.reduce((best, s) => (s.workspace.length > best.workspace.length ? s : best))
+    .name;
+}
+
+/**
+ * Accepts the documented `sbx ls --json` shape (a `SANDBOX`/`WORKSPACE` table serialized as
+ * objects) plus a couple of reasonable variants, and degrades to no sandboxes rather than throw.
+ */
+export function parseSandboxList(value: unknown): SandboxInfo[] {
+  const list = Array.isArray(value)
+    ? value
+    : value !== null &&
+        typeof value === "object" &&
+        Array.isArray((value as { sandboxes?: unknown }).sandboxes)
+      ? (value as { sandboxes: unknown[] }).sandboxes
+      : [];
+
+  return list.flatMap((item): SandboxInfo[] => {
+    if (typeof item !== "object" || item === null) return [];
+    const fields = item as Record<string, unknown>;
+    const name = fields.name ?? fields.sandbox;
+    if (typeof name !== "string" || name === "") return [];
+    const workspace = fields.workspace;
+    return [{ name, workspace: typeof workspace === "string" ? workspace : undefined }];
+  });
+}
+
+export const realSandboxLookup: SandboxLookup = {
+  exists: existsSync,
+  listSandboxes: () => {
+    const r = spawnSync("sbx", ["ls", "--json"], { encoding: "utf8" });
+    if (r.status !== 0 || !r.stdout) return [];
+    return parseSandboxList(JSON.parse(r.stdout));
+  },
+};

--- a/tests/herdr.test.ts
+++ b/tests/herdr.test.ts
@@ -2,27 +2,87 @@ import { describe, expect, it } from "vitest";
 import { join } from "node:path";
 import { DEFAULTS } from "../src/config.js";
 import { HerdrAdapter, resolveHunkLauncher } from "../src/herdr.js";
+import type { SandboxLookup } from "../src/sandbox.js";
+
+/** Worktree "exists" locally, so these tests never reach for a sandbox. */
+const LOCAL_LOOKUP: SandboxLookup = { exists: () => true, listSandboxes: () => [] };
 
 describe("resolveHunkLauncher", () => {
   it("prefers the bundled hunkdiff when bin is auto", () => {
-    expect(resolveHunkLauncher(DEFAULTS, "/plugin", "/bin/node")).toEqual({
+    expect(resolveHunkLauncher(DEFAULTS, "/plugin", "/wt", "/bin/node", LOCAL_LOOKUP)).toEqual({
       bin: "/bin/node",
       prefix: [join("/plugin", "node_modules", "hunkdiff", "bin", "hunk.cjs")],
     });
   });
 
   it("runs it under this process's own node by default", () => {
-    expect(resolveHunkLauncher(DEFAULTS, "/plugin").bin).toBe(process.execPath);
+    expect(resolveHunkLauncher(DEFAULTS, "/plugin", "/wt", undefined, LOCAL_LOOKUP).bin).toBe(
+      process.execPath,
+    );
   });
 
   it("never reaches for the node_modules/.bin shim", () => {
-    const { bin, prefix } = resolveHunkLauncher(DEFAULTS, "/plugin");
+    const { bin, prefix } = resolveHunkLauncher(
+      DEFAULTS,
+      "/plugin",
+      "/wt",
+      undefined,
+      LOCAL_LOOKUP,
+    );
     expect([bin, ...prefix].join(" ")).not.toContain(".bin");
   });
 
   it("honours an explicit binary path, spawning it with no launcher in front", () => {
     const cfg = { ...DEFAULTS, hunk: { ...DEFAULTS.hunk, bin: "/usr/local/bin/hunk" } };
-    expect(resolveHunkLauncher(cfg, "/plugin")).toEqual({ bin: "/usr/local/bin/hunk", prefix: [] });
+    expect(resolveHunkLauncher(cfg, "/plugin", "/wt")).toEqual({
+      bin: "/usr/local/bin/hunk",
+      prefix: [],
+    });
+  });
+
+  describe("Docker Sandbox fallback", () => {
+    it("routes through sbx exec when the worktree only exists inside a matching sandbox", () => {
+      const lookup: SandboxLookup = {
+        exists: () => false,
+        listSandboxes: () => [{ name: "my-sandbox", workspace: "/wt/project" }],
+      };
+      expect(resolveHunkLauncher(DEFAULTS, "/plugin", "/wt/project", "/bin/node", lookup)).toEqual({
+        bin: "sbx",
+        prefix: ["exec", "my-sandbox", "hunk"],
+      });
+    });
+
+    it("falls back to local hunk when no sandbox matches", () => {
+      const lookup: SandboxLookup = { exists: () => false, listSandboxes: () => [] };
+      expect(resolveHunkLauncher(DEFAULTS, "/plugin", "/wt/project", "/bin/node", lookup)).toEqual({
+        bin: "/bin/node",
+        prefix: [join("/plugin", "node_modules", "hunkdiff", "bin", "hunk.cjs")],
+      });
+    });
+
+    it("falls back to local hunk when sbx itself is unavailable", () => {
+      const lookup: SandboxLookup = {
+        exists: () => false,
+        listSandboxes: () => {
+          throw new Error("spawn sbx ENOENT");
+        },
+      };
+      expect(resolveHunkLauncher(DEFAULTS, "/plugin", "/wt/project", "/bin/node", lookup).bin).toBe(
+        "/bin/node",
+      );
+    });
+
+    it("does not consult sbx at all when the worktree already exists locally", () => {
+      let called = false;
+      resolveHunkLauncher(DEFAULTS, "/plugin", "/wt", "/bin/node", {
+        exists: () => true,
+        listSandboxes: () => {
+          called = true;
+          return [];
+        },
+      });
+      expect(called).toBe(false);
+    });
   });
 });
 

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { findSandboxForPath, parseSandboxList } from "../src/sandbox.js";
+
+describe("findSandboxForPath", () => {
+  it("matches a sandbox whose workspace is exactly the path", () => {
+    expect(findSandboxForPath("/wt/project", [{ name: "s1", workspace: "/wt/project" }])).toBe(
+      "s1",
+    );
+  });
+
+  it("matches a sandbox whose workspace is an ancestor of the path", () => {
+    expect(
+      findSandboxForPath("/wt/project/src/deep", [{ name: "s1", workspace: "/wt/project" }]),
+    ).toBe("s1");
+  });
+
+  it("does not mistake a sibling directory with a shared prefix for a child", () => {
+    expect(
+      findSandboxForPath("/wt/project-x", [{ name: "s1", workspace: "/wt/project" }]),
+    ).toBeUndefined();
+  });
+
+  it("ignores sandboxes with no workspace", () => {
+    expect(findSandboxForPath("/wt/project", [{ name: "s1" }])).toBeUndefined();
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(
+      findSandboxForPath("/wt/other", [{ name: "s1", workspace: "/wt/project" }]),
+    ).toBeUndefined();
+  });
+
+  it("prefers the most specific (longest) matching workspace", () => {
+    expect(
+      findSandboxForPath("/wt/project/src", [
+        { name: "outer", workspace: "/wt" },
+        { name: "inner", workspace: "/wt/project" },
+      ]),
+    ).toBe("inner");
+  });
+});
+
+describe("parseSandboxList", () => {
+  it("reads a bare array of sandbox rows", () => {
+    expect(parseSandboxList([{ name: "s1", workspace: "/wt/project" }])).toEqual([
+      { name: "s1", workspace: "/wt/project" },
+    ]);
+  });
+
+  it("reads a {sandboxes: [...]} wrapper", () => {
+    expect(parseSandboxList({ sandboxes: [{ name: "s1", workspace: "/wt/project" }] })).toEqual([
+      { name: "s1", workspace: "/wt/project" },
+    ]);
+  });
+
+  it("accepts a `sandbox` field as the name when `name` is absent", () => {
+    expect(parseSandboxList([{ sandbox: "s1", workspace: "/wt/project" }])).toEqual([
+      { name: "s1", workspace: "/wt/project" },
+    ]);
+  });
+
+  it("drops a row with no usable name rather than throwing", () => {
+    expect(parseSandboxList([{ workspace: "/wt/project" }])).toEqual([]);
+  });
+
+  it("keeps a row whose workspace is missing, as undefined", () => {
+    expect(parseSandboxList([{ name: "s1" }])).toEqual([{ name: "s1", workspace: undefined }]);
+  });
+
+  it("degrades to no sandboxes for shapes it does not recognize", () => {
+    expect(parseSandboxList(null)).toEqual([]);
+    expect(parseSandboxList("not json")).toEqual([]);
+    expect(parseSandboxList({})).toEqual([]);
+    expect(parseSandboxList([null, 42, "x"])).toEqual([]);
+  });
+});


### PR DESCRIPTION
When a review's worktree does not exist on this filesystem (e.g. an agent working in a Docker Sandbox --clone checkout), resolve a matching sandbox via `sbx ls --json` and run hunk there through `sbx exec <sandbox> -- hunk` instead of the bundled local binary. Any failure along that path (no sbx, no matching sandbox, bad JSON) falls back to today's local hunk launch.